### PR TITLE
Static component

### DIFF
--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -243,19 +243,47 @@ namespace Coffee
         if (entity.HasComponent<TagComponent>())
         {
             auto& entityNameTag = entity.GetComponent<TagComponent>().Tag;
-
+        
             ImGui::Text(ICON_LC_TAG " Tag");
             ImGui::SameLine();
-
+        
+            // Make the tag input field smaller to accommodate the "Static" checkbox
+            float availableWidth = ImGui::GetContentRegionAvail().x;
+            float tagInputWidth = availableWidth * 0.7f; // Use 70% of the width for the tag input
+        
+            // Set the width of the input field
+            ImGui::PushItemWidth(tagInputWidth);
+        
             char buffer[256];
             memset(buffer, 0, sizeof(buffer));
             strcpy(buffer, entityNameTag.c_str());
-
+        
             if (ImGui::InputText("##", buffer, sizeof(buffer)))
             {
                 entityNameTag = std::string(buffer);
             }
-
+            
+            ImGui::PopItemWidth();
+        
+            // Add a small space
+            ImGui::SameLine();
+            
+            // Add the "Static" checkbox
+            bool isStatic = entity.HasComponent<StaticComponent>();
+            if (ImGui::Checkbox("Static", &isStatic))
+            {
+                if (isStatic)
+                {
+                    if (!entity.HasComponent<StaticComponent>())
+                        entity.AddComponent<StaticComponent>();
+                }
+                else
+                {
+                    if (entity.HasComponent<StaticComponent>())
+                        entity.RemoveComponent<StaticComponent>();
+                }
+            }
+        
             ImGui::Separator();
         }
 

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
@@ -962,6 +962,25 @@
             archive(cereal::make_nvp("Active", active));
         }
     };
+
+    struct StaticComponent
+    {
+        StaticComponent() = default;
+        StaticComponent(const StaticComponent&) = default;
+
+        template<class Archive>
+        void save (Archive& archive) const
+        {
+            archive(cereal::make_nvp("Static", true));
+        }
+
+        template<class Archive>
+        void load (Archive& archive)
+        {
+            bool active;
+            archive(cereal::make_nvp("Static", active));
+        }
+    };
  }
  
  /** @} */

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
@@ -950,17 +950,10 @@
         ActiveComponent(const ActiveComponent&) = default;
 
         template<class Archive>
-        void save (Archive& archive) const
-        {
-            archive(cereal::make_nvp("Active", true));
-        }
+        void save (Archive& archive) const {}
 
         template<class Archive>
-        void load (Archive& archive)
-        {
-            bool active;
-            archive(cereal::make_nvp("Active", active));
-        }
+        void load (Archive& archive) {}
     };
 
     struct StaticComponent
@@ -969,17 +962,10 @@
         StaticComponent(const StaticComponent&) = default;
 
         template<class Archive>
-        void save (Archive& archive) const
-        {
-            archive(cereal::make_nvp("Static", true));
-        }
+        void save (Archive& archive) const {}
 
         template<class Archive>
-        void load (Archive& archive)
-        {
-            bool active;
-            archive(cereal::make_nvp("Static", active));
-        }
+        void load (Archive& archive) {}
     };
  }
  

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
@@ -165,7 +165,8 @@ namespace Coffee {
             .template get<AudioListenerComponent>(archive)
             .template get<AudioZoneComponent>(archive)
             .template get<ParticlesSystemComponent>(archive)
-            .template get<ActiveComponent>(archive);
+            .template get<ActiveComponent>(archive)
+            .template get<StaticComponent>(archive);
          }
 
         /**
@@ -194,7 +195,8 @@ namespace Coffee {
             .template get<AudioListenerComponent>(archive)
             .template get<AudioZoneComponent>(archive)
             .template get<ParticlesSystemComponent>(archive)
-            .template get<ActiveComponent>(archive);
+            .template get<ActiveComponent>(archive)
+            .template get<StaticComponent>(archive);
 
 
             AssignAnimatorsToMeshes(AnimationSystem::GetAnimators());


### PR DESCRIPTION
This pull request introduces the `StaticComponent` to the engine.

### Introduction of `StaticComponent`:

* [`CoffeeEngine/src/CoffeeEngine/Scene/Components.h`](diffhunk://#diff-c0f0d1ff7d1326585568b45a34a4e54f42cf329b050a595a693bd541cec8828bR965-R983): Added the `StaticComponent` struct with serialization support using the `cereal` library.

### Serialization updates:

* [`CoffeeEngine/src/CoffeeEngine/Scene/Scene.h`](diffhunk://#diff-aea9a2acf834d2e4ea478a6d6620fec582f621da77bdcc5c02e754d27c9542bfL168-R169): Updated the `Scene` class to include the `StaticComponent` in the serialization process. [[1]](diffhunk://#diff-aea9a2acf834d2e4ea478a6d6620fec582f621da77bdcc5c02e754d27c9542bfL168-R169) [[2]](diffhunk://#diff-aea9a2acf834d2e4ea478a6d6620fec582f621da77bdcc5c02e754d27c9542bfL197-R199)

### UI updates in `CoffeeEditor`:

* [`CoffeeEditor/Panels/SceneTreePanel.cpp`](diffhunk://#diff-261f606e9d2f2dadf6d17fa21950d888b0e5f5ff11a409d842e740f0ee6926a7R250-R256): Modified the `SceneTreePanel` to include a checkbox for the `StaticComponent`. Adjusted the tag input field width to accommodate the new checkbox. [[1]](diffhunk://#diff-261f606e9d2f2dadf6d17fa21950d888b0e5f5ff11a409d842e740f0ee6926a7R250-R256) [[2]](diffhunk://#diff-261f606e9d2f2dadf6d17fa21950d888b0e5f5ff11a409d842e740f0ee6926a7R266-R286)