### PR TITLE
Prefabs

### DIFF
--- a/CoffeeEditor/Panels/ProjectSettingsPanel.cpp
+++ b/CoffeeEditor/Panels/ProjectSettingsPanel.cpp
@@ -160,6 +160,7 @@ namespace Coffee {
             static std::string newBindName;
             newBindName = m_SelectedInputKey;
             ImGui::TextUnformatted("Name: "); ImGui::SameLine();
+            /*
             if (ImGui::InputText("BindingName", &newBindName, ImGuiInputTextFlags_EnterReturnsTrue))
             {
                 if (newBindName.length() != 0)
@@ -172,6 +173,7 @@ namespace Coffee {
                     m_SelectedInputKey = newBindName;
                 }
             }
+            */
             ImGui::NewLine();
             ImGui::TextUnformatted("PosButton:"); ImGui::SameLine();
             ImGui::Text("%s", Input::GetButtonLabel(m_SelectedInputBinding->ButtonPos)); ImGui::SameLine();

--- a/CoffeeEditor/Panels/ProjectSettingsPanel.cpp
+++ b/CoffeeEditor/Panels/ProjectSettingsPanel.cpp
@@ -160,7 +160,6 @@ namespace Coffee {
             static std::string newBindName;
             newBindName = m_SelectedInputKey;
             ImGui::TextUnformatted("Name: "); ImGui::SameLine();
-            /*
             if (ImGui::InputText("BindingName", &newBindName, ImGuiInputTextFlags_EnterReturnsTrue))
             {
                 if (newBindName.length() != 0)
@@ -173,7 +172,6 @@ namespace Coffee {
                     m_SelectedInputKey = newBindName;
                 }
             }
-            */
             ImGui::NewLine();
             ImGui::TextUnformatted("PosButton:"); ImGui::SameLine();
             ImGui::Text("%s", Input::GetButtonLabel(m_SelectedInputBinding->ButtonPos)); ImGui::SameLine();

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -146,10 +146,59 @@ namespace Coffee
         {
             m_SelectionContext = entity;
         }
+
+        if (ImGui::BeginPopup("EntityContextMenu"))
+        {
+            if (ImGui::MenuItem("Create Prefab"))
+            {
+                CreatePrefab(m_SelectionContext);
+                ImGui::CloseCurrentPopup();
+            }
+            
+            // For the Prefabs menu
+            if (ImGui::BeginMenu("Prefabs"))
+            {
+                // List recently used prefabs
+                for (const auto& path : m_RecentPrefabs)
+                {
+                    if (ImGui::MenuItem(path.filename().string().c_str()))
+                    {
+                        InstantiatePrefab(path);
+                    }
+                }
+                
+                if (ImGui::MenuItem("Browse..."))
+                {
+                    FileDialogArgs args;
+                    args.Filters = {{"Prefab", "prefab"}};
+                    auto path = FileDialog::OpenFile(args);
+                    if (!path.empty())
+                    {
+                        InstantiatePrefab(path);
+                        // Add to recent prefabs list if not already there
+                        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end())
+                        {
+                            m_RecentPrefabs.push_back(path);
+                            // Keep only the last 5 prefabs
+                            if (m_RecentPrefabs.size() > 5)
+                                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
+                        }
+                    }
+                }
+                
+                ImGui::EndMenu();
+            }
+            ImGui::EndPopup();
+        }
     
         // Code of Double clicking the item for changing the name (WIP)
         ImVec2 itemSize = ImGui::GetItemRectSize();
     
+        if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
+        {
+            ImGui::OpenPopup("EntityContextMenu");
+        }
+
         if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
         {
             ImVec2 popupPos = ImGui::GetItemRectMin();
@@ -2444,49 +2493,6 @@ namespace Coffee
             }
 
             ImGui::EndPopup();
-        }
-
-        if (ImGui::BeginPopupContextItem())
-        {
-            if (ImGui::MenuItem("Create Prefab"))
-            {
-                CreatePrefab(m_SelectionContext);
-                ImGui::CloseCurrentPopup();
-            }
-            
-            // For the Prefabs menu
-            if (ImGui::BeginMenu("Prefabs"))
-            {
-                // List recently used prefabs
-                for (const auto& path : m_RecentPrefabs)
-                {
-                    if (ImGui::MenuItem(path.filename().string().c_str()))
-                    {
-                        InstantiatePrefab(path);
-                    }
-                }
-                
-                if (ImGui::MenuItem("Browse..."))
-                {
-                    FileDialogArgs args;
-                    args.Filters = {{"Prefab", "prefab"}};
-                    auto path = FileDialog::OpenFile(args);
-                    if (!path.empty())
-                    {
-                        InstantiatePrefab(path);
-                        // Add to recent prefabs list if not already there
-                        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end())
-                        {
-                            m_RecentPrefabs.push_back(path);
-                            // Keep only the last 5 prefabs
-                            if (m_RecentPrefabs.size() > 5)
-                                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
-                        }
-                    }
-                }
-                
-                ImGui::EndMenu();
-            }
         }
     }
 

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -177,11 +177,21 @@ namespace Coffee
             m_SelectionContext = entity;
         }
 
-        if (ImGui::BeginPopup("EntityContextMenu"))
+        // Create a unique popup ID for each entity to prevent collisions
+        std::string contextMenuId = "EntityContextMenu##" + std::to_string((uint32_t)(uint64_t)(entt::entity)entity);
+
+        if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
+        {
+            // Set the selection context to this entity and open its unique popup
+            m_SelectionContext = entity;
+            ImGui::OpenPopup(contextMenuId.c_str());
+        }
+
+        if (ImGui::BeginPopup(contextMenuId.c_str()))
         {
             if (ImGui::MenuItem("Create Prefab"))
             {
-                CreatePrefab(m_SelectionContext);
+                CreatePrefab(entity);
                 ImGui::CloseCurrentPopup();
             }
             ImGui::EndPopup();
@@ -190,11 +200,6 @@ namespace Coffee
         // Code of Double clicking the item for changing the name (WIP)
         ImVec2 itemSize = ImGui::GetItemRectSize();
     
-        if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
-        {
-            ImGui::OpenPopup("EntityContextMenu");
-        }
-
         if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
         {
             ImVec2 popupPos = ImGui::GetItemRectMin();

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -9,6 +9,7 @@
 #include "CoffeeEngine/Renderer/Texture.h"
 #include "CoffeeEngine/Scene/Components.h"
 #include "CoffeeEngine/Scene/Entity.h"
+#include "CoffeeEngine/Scene/Prefab.h"
 #include "CoffeeEngine/Scene/PrimitiveMesh.h"
 #include "CoffeeEngine/Scene/Scene.h"
 #include "CoffeeEngine/Scene/SceneCamera.h"
@@ -2444,6 +2445,49 @@ namespace Coffee
 
             ImGui::EndPopup();
         }
+
+        if (ImGui::BeginPopupContextItem())
+        {
+            if (ImGui::MenuItem("Create Prefab"))
+            {
+                CreatePrefab(m_SelectionContext);
+                ImGui::CloseCurrentPopup();
+            }
+            
+            // For the Prefabs menu
+            if (ImGui::BeginMenu("Prefabs"))
+            {
+                // List recently used prefabs
+                for (const auto& path : m_RecentPrefabs)
+                {
+                    if (ImGui::MenuItem(path.filename().string().c_str()))
+                    {
+                        InstantiatePrefab(path);
+                    }
+                }
+                
+                if (ImGui::MenuItem("Browse..."))
+                {
+                    FileDialogArgs args;
+                    args.Filters = {{"Prefab", "prefab"}};
+                    auto path = FileDialog::OpenFile(args);
+                    if (!path.empty())
+                    {
+                        InstantiatePrefab(path);
+                        // Add to recent prefabs list if not already there
+                        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end())
+                        {
+                            m_RecentPrefabs.push_back(path);
+                            // Keep only the last 5 prefabs
+                            if (m_RecentPrefabs.size() > 5)
+                                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
+                        }
+                    }
+                }
+                
+                ImGui::EndMenu();
+            }
+        }
     }
 
     bool SceneTreePanel::ResizeColliderToFitMeshAABB(Entity entity, RigidbodyComponent& rbComponent)
@@ -2480,5 +2524,52 @@ namespace Coffee
         }
         
         return false;
+    }
+    
+    void SceneTreePanel::CreatePrefab(Entity entity)
+    {
+        if (!entity)
+            return;
+            
+        FileDialogArgs args;
+        args.Filters = {{"Prefab", "prefab"}};
+        args.DefaultName = entity.GetComponent<TagComponent>().Tag + ".prefab";
+        const std::filesystem::path& path = FileDialog::SaveFile(args);
+        
+        if (path.empty())
+            return;
+            
+        Ref<Prefab> prefab = Prefab::Create(entity);
+        prefab->Save(path);
+        
+        // Add to recent prefabs
+        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end()) {
+            m_RecentPrefabs.push_back(path);
+            // Keep only last 5 prefabs
+            if (m_RecentPrefabs.size() > 5)
+                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
+        }
+        
+        COFFEE_CORE_INFO("Created prefab: {0}", path.string());
+    }
+    
+    void SceneTreePanel::InstantiatePrefab(const std::filesystem::path& path)
+    {
+        Ref<Prefab> prefab = Prefab::Load(path);
+        if (!prefab)
+            return;
+            
+        Entity instance = prefab->Instantiate(m_Context.get());
+        SetSelectedEntity(instance);
+        
+        // Add to recent prefabs if not already there
+        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end()) {
+            m_RecentPrefabs.push_back(path);
+            // Keep only last 5 prefabs
+            if (m_RecentPrefabs.size() > 5)
+                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
+        }
+        
+        COFFEE_CORE_INFO("Instantiated prefab: {0}", path.string());
     }
 } // namespace Coffee

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -91,6 +91,7 @@ namespace Coffee
         ImGui::EndChild();
 
         // Entity Tree Drag and Drop functionality
+                // Entity Tree Drag and Drop functionality
         if (ImGui::BeginDragDropTarget())
         {
             if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("RESOURCE"))
@@ -103,9 +104,19 @@ namespace Coffee
                     AddModelToTheSceneTree(m_Context.get(), model);
                     break;
                 }
-                default:
+                case ResourceType::Prefab: {
+                    // Get the prefab and instantiate it in the scene
+                    Ref<Prefab> prefab = std::static_pointer_cast<Prefab>(resource);
+                    if (prefab)
+                    {
+                        InstantiatePrefab(prefab->GetPath());
+                    }
                     break;
                 }
+                default: {
+                    break;
+                }
+                } // This closing brace was missing in the original code
             }
             ImGui::EndDragDropTarget();
         }
@@ -153,40 +164,6 @@ namespace Coffee
             {
                 CreatePrefab(m_SelectionContext);
                 ImGui::CloseCurrentPopup();
-            }
-            
-            // For the Prefabs menu
-            if (ImGui::BeginMenu("Prefabs"))
-            {
-                // List recently used prefabs
-                for (const auto& path : m_RecentPrefabs)
-                {
-                    if (ImGui::MenuItem(path.filename().string().c_str()))
-                    {
-                        InstantiatePrefab(path);
-                    }
-                }
-                
-                if (ImGui::MenuItem("Browse..."))
-                {
-                    FileDialogArgs args;
-                    args.Filters = {{"Prefab", "prefab"}};
-                    auto path = FileDialog::OpenFile(args);
-                    if (!path.empty())
-                    {
-                        InstantiatePrefab(path);
-                        // Add to recent prefabs list if not already there
-                        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end())
-                        {
-                            m_RecentPrefabs.push_back(path);
-                            // Keep only the last 5 prefabs
-                            if (m_RecentPrefabs.size() > 5)
-                                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
-                        }
-                    }
-                }
-                
-                ImGui::EndMenu();
             }
             ImGui::EndPopup();
         }

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -91,9 +91,9 @@ namespace Coffee
         ImGui::EndChild();
 
         // Entity Tree Drag and Drop functionality
-                // Entity Tree Drag and Drop functionality
         if (ImGui::BeginDragDropTarget())
         {
+            // Handle normal resources (like models)
             if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("RESOURCE"))
             {
                 const Ref<Resource>& resource = *(Ref<Resource>*)payload->Data;
@@ -105,19 +105,38 @@ namespace Coffee
                     break;
                 }
                 case ResourceType::Prefab: {
-                    // Get the prefab and instantiate it in the scene
-                    Ref<Prefab> prefab = std::static_pointer_cast<Prefab>(resource);
-                    if (prefab)
+                    if (const Ref<Prefab> prefab = std::static_pointer_cast<Prefab>(resource))
                     {
-                        InstantiatePrefab(prefab->GetPath());
+                        const Entity instance = prefab->Instantiate(m_Context.get());
+                        SetSelectedEntity(instance);
+                        
+                        COFFEE_CORE_INFO("Instantiated prefab: {0}", prefab->GetPath().string());
                     }
                     break;
                 }
                 default: {
                     break;
                 }
-                } // This closing brace was missing in the original code
+                } // End of switch
             }
+
+            // Handle prefab paths - only load the prefab when it's actually dropped
+            if (const ImGuiPayload* prefabPayload = ImGui::AcceptDragDropPayload("PREFAB_PATH"))
+            {
+                const char* pathStr = (const char*)prefabPayload->Data;
+                std::filesystem::path prefabPath = pathStr;
+                
+                // Load the prefab now that it's being used
+                Ref<Prefab> prefab = Prefab::Load(prefabPath);
+                if (prefab)
+                {
+                    Entity instance = prefab->Instantiate(m_Context.get());
+                    SetSelectedEntity(instance);
+                    
+                    COFFEE_CORE_INFO("Instantiated prefab: {0}", prefabPath.string());
+                }
+            }
+            
             ImGui::EndDragDropTarget();
         }
 
@@ -2521,38 +2540,10 @@ namespace Coffee
         
         if (path.empty())
             return;
-            
-        Ref<Prefab> prefab = Prefab::Create(entity);
+
+        const Ref<Prefab> prefab = Prefab::Create(entity);
         prefab->Save(path);
         
-        // Add to recent prefabs
-        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end()) {
-            m_RecentPrefabs.push_back(path);
-            // Keep only last 5 prefabs
-            if (m_RecentPrefabs.size() > 5)
-                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
-        }
-        
         COFFEE_CORE_INFO("Created prefab: {0}", path.string());
-    }
-    
-    void SceneTreePanel::InstantiatePrefab(const std::filesystem::path& path)
-    {
-        Ref<Prefab> prefab = Prefab::Load(path);
-        if (!prefab)
-            return;
-            
-        Entity instance = prefab->Instantiate(m_Context.get());
-        SetSelectedEntity(instance);
-        
-        // Add to recent prefabs if not already there
-        if (std::find(m_RecentPrefabs.begin(), m_RecentPrefabs.end(), path) == m_RecentPrefabs.end()) {
-            m_RecentPrefabs.push_back(path);
-            // Keep only last 5 prefabs
-            if (m_RecentPrefabs.size() > 5)
-                m_RecentPrefabs.erase(m_RecentPrefabs.begin());
-        }
-        
-        COFFEE_CORE_INFO("Instantiated prefab: {0}", path.string());
     }
 } // namespace Coffee

--- a/CoffeeEditor/Panels/SceneTreePanel.h
+++ b/CoffeeEditor/Panels/SceneTreePanel.h
@@ -22,7 +22,6 @@ namespace Coffee {
         void SetSelectedEntity(Entity entity) { m_SelectionContext = entity; };
 
         void CreatePrefab(Entity entity);
-        void InstantiatePrefab(const std::filesystem::path& path);
 
     private:
         void DrawEntityNode(Entity entity);

--- a/CoffeeEditor/Panels/SceneTreePanel.h
+++ b/CoffeeEditor/Panels/SceneTreePanel.h
@@ -35,7 +35,6 @@ namespace Coffee {
     private:
         Ref<Scene> m_Context;
         Entity m_SelectionContext;
-        std::vector<std::filesystem::path> m_RecentPrefabs;
 
         bool m_ShowLuaScriptOptions = false;
     };

--- a/CoffeeEditor/Panels/SceneTreePanel.h
+++ b/CoffeeEditor/Panels/SceneTreePanel.h
@@ -21,6 +21,9 @@ namespace Coffee {
         Entity GetSelectedEntity() const { return m_SelectionContext; };
         void SetSelectedEntity(Entity entity) { m_SelectionContext = entity; };
 
+        void CreatePrefab(Entity entity);
+        void InstantiatePrefab(const std::filesystem::path& path);
+
     private:
         void DrawEntityNode(Entity entity);
         void DrawComponents(Entity entity);
@@ -32,6 +35,7 @@ namespace Coffee {
     private:
         Ref<Scene> m_Context;
         Entity m_SelectionContext;
+        std::vector<std::filesystem::path> m_RecentPrefabs;
 
         bool m_ShowLuaScriptOptions = false;
     };

--- a/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
@@ -34,6 +34,7 @@ namespace Coffee {
         Skeleton, ///< Skeleton resource type
         Animation, ///< Animation resource type
         AnimationController, ///< AnimationController resource type
+        Prefab, ///< Prefab resource type
     };
 
     /**
@@ -66,6 +67,8 @@ namespace Coffee {
          * @return The file path of the resource.
          */
         const std::filesystem::path& GetPath() { COFFEE_CORE_ASSERT(m_FilePath.empty(), "This Texture does not exist on disk!"); return m_FilePath; }
+
+        void SetPath(const std::filesystem::path& path) { m_FilePath = path; }
 
         /**
          * @brief Sets the name of the mesh.

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
@@ -33,6 +33,10 @@ namespace Coffee {
         {
             return ResourceType::Shader;
         }
+        else if(extension == ".prefab")
+        {
+            return ResourceType::Prefab;
+        }
 
         return ResourceType::Unknown;
     }
@@ -53,6 +57,8 @@ namespace Coffee {
             return "Shader";
         case ResourceType::Material:
             return "Material";
+        case ResourceType::Prefab:
+            return "Prefab";
         default:
             return "Unknown";
         }

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -235,7 +235,6 @@ namespace Coffee {
             archive(*this);
 
             SetPath(path);
-            ResourceRegistry::Add(UUID(), Ref<Resource>(this));
 
             return true;
         }

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -154,10 +154,17 @@ namespace Coffee {
             entity.AddComponent<StaticComponent>();
         }
 
+        // We don't want to add the ActiveComponent to the prefab instance
+        // as it will be added to the entity when it is added to the scene
+        //
+        // Because of that, we can't have a Prefab without an ActiveComponent.
+        // TODO Make it possible to have a prefab without an ActiveComponent
+        /*
         if (m_Registry.all_of<ActiveComponent>(prefabEntity))
         {
             entity.AddComponent<ActiveComponent>();
         }
+        */
 
         if (parent)
         {

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -191,12 +191,6 @@ namespace Coffee {
             entity.AddComponent<NavMeshComponent>(navMeshComp);
         }
 
-        if (m_Registry.all_of<ParticlesSystemComponent>(prefabEntity))
-        {
-            const auto& particlesComp = m_Registry.get<ParticlesSystemComponent>(prefabEntity);
-            entity.AddComponent<ParticlesSystemComponent>(particlesComp);
-        }
-
         if (m_Registry.all_of<StaticComponent>(prefabEntity))
         {
             entity.AddComponent<StaticComponent>();

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -213,13 +213,18 @@ namespace Coffee {
             entity.SetParent(parent);
         }
 
-        auto& hierarchy = m_Registry.get<HierarchyComponent>(prefabEntity);
-        entt::entity childEntity = hierarchy.m_First;
+        // Find and process all child entities of this entity
+        // This approach directly queries for all entities that have the current entity as parent
+        // instead of following the sibling chain (m_First -> m_Next links).
+        // This is safer than the sibling chain.
+        std::vector<entt::entity> childEntities;
+        m_Registry.view<HierarchyComponent>().each([&](entt::entity e, const HierarchyComponent& h) {
+            if (h.m_Parent == prefabEntity)
+                childEntities.push_back(e);
+        });
 
-        while (childEntity != entt::null)
-        {
+        for (auto childEntity : childEntities) {
             CopyEntityToScene(scene, childEntity, entity);
-            childEntity = m_Registry.get<HierarchyComponent>(childEntity).m_Next;
         }
 
         return entity;

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -103,97 +103,97 @@ namespace Coffee {
         return instance;
     }
 
-    Entity Prefab::CopyEntityToScene(Scene* scene, entt::entity prefabEntity, Entity parent)
+    Entity Prefab::CopyEntityToScene(Scene* scene, const entt::entity prefabEntity, const Entity parent)
     {
         Entity entity = scene->CreateEntity();
 
         if (m_Registry.all_of<TagComponent>(prefabEntity))
         {
-            auto& tag = m_Registry.get<TagComponent>(prefabEntity);
+            const auto& tag = m_Registry.get<TagComponent>(prefabEntity);
             entity.GetComponent<TagComponent>().Tag = tag.Tag;
         }
 
         if (m_Registry.all_of<TransformComponent>(prefabEntity))
         {
-            auto& transform = m_Registry.get<TransformComponent>(prefabEntity);
+            const auto& transform = m_Registry.get<TransformComponent>(prefabEntity);
             entity.GetComponent<TransformComponent>() = transform;
         }
 
         if (m_Registry.all_of<MeshComponent>(prefabEntity))
         {
-            auto& meshComp = m_Registry.get<MeshComponent>(prefabEntity);
+            const auto& meshComp = m_Registry.get<MeshComponent>(prefabEntity);
             entity.AddComponent<MeshComponent>(meshComp);
         }
 
         if (m_Registry.all_of<MaterialComponent>(prefabEntity))
         {
-            auto& matComp = m_Registry.get<MaterialComponent>(prefabEntity);
+            const auto& matComp = m_Registry.get<MaterialComponent>(prefabEntity);
             entity.AddComponent<MaterialComponent>(matComp);
         }
 
         if (m_Registry.all_of<LightComponent>(prefabEntity))
         {
-            auto& lightComp = m_Registry.get<LightComponent>(prefabEntity);
+            const auto& lightComp = m_Registry.get<LightComponent>(prefabEntity);
             entity.AddComponent<LightComponent>(lightComp);
         }
 
         if (m_Registry.all_of<RigidbodyComponent>(prefabEntity))
         {
-            auto& rbComp = m_Registry.get<RigidbodyComponent>(prefabEntity);
+            const auto& rbComp = m_Registry.get<RigidbodyComponent>(prefabEntity);
             entity.AddComponent<RigidbodyComponent>(rbComp);
         }
 
         if (m_Registry.all_of<ParticlesSystemComponent>(prefabEntity))
         {
-            auto& particlesComp = m_Registry.get<ParticlesSystemComponent>(prefabEntity);
+            const auto& particlesComp = m_Registry.get<ParticlesSystemComponent>(prefabEntity);
             entity.AddComponent<ParticlesSystemComponent>(particlesComp);
         }
 
         if (m_Registry.all_of<ScriptComponent>(prefabEntity))
         {
-            auto& scriptComp = m_Registry.get<ScriptComponent>(prefabEntity);
+            const auto& scriptComp = m_Registry.get<ScriptComponent>(prefabEntity);
             entity.AddComponent<ScriptComponent>(scriptComp);
         }
 
         if (m_Registry.all_of<AnimatorComponent>(prefabEntity))
         {
-            auto& animatorComp = m_Registry.get<AnimatorComponent>(prefabEntity);
+            const auto& animatorComp = m_Registry.get<AnimatorComponent>(prefabEntity);
             entity.AddComponent<AnimatorComponent>(animatorComp);
         }
 
         if (m_Registry.all_of<AudioSourceComponent>(prefabEntity))
         {
-            auto& audioSourceComp = m_Registry.get<AudioSourceComponent>(prefabEntity);
+            const auto& audioSourceComp = m_Registry.get<AudioSourceComponent>(prefabEntity);
             entity.AddComponent<AudioSourceComponent>(audioSourceComp);
         }
 
         if (m_Registry.all_of<AudioListenerComponent>(prefabEntity))
         {
-            auto& audioListenerComp = m_Registry.get<AudioListenerComponent>(prefabEntity);
+            const auto& audioListenerComp = m_Registry.get<AudioListenerComponent>(prefabEntity);
             entity.AddComponent<AudioListenerComponent>(audioListenerComp);
         }
 
         if (m_Registry.all_of<AudioZoneComponent>(prefabEntity))
         {
-            auto& audioZoneComp = m_Registry.get<AudioZoneComponent>(prefabEntity);
+            const auto& audioZoneComp = m_Registry.get<AudioZoneComponent>(prefabEntity);
             entity.AddComponent<AudioZoneComponent>(audioZoneComp);
         }
 
         if (m_Registry.all_of<NavigationAgentComponent>(prefabEntity))
         {
-            auto& navAgentComp = m_Registry.get<NavigationAgentComponent>(prefabEntity);
+            const auto& navAgentComp = m_Registry.get<NavigationAgentComponent>(prefabEntity);
             entity.AddComponent<NavigationAgentComponent>(navAgentComp);
         }
 
         if (m_Registry.all_of<NavMeshComponent>(prefabEntity))
         {
-            auto& navMeshComp = m_Registry.get<NavMeshComponent>(prefabEntity);
+            const auto& navMeshComp = m_Registry.get<NavMeshComponent>(prefabEntity);
             entity.AddComponent<NavMeshComponent>(navMeshComp);
         }
 
         if (m_Registry.all_of<ParticlesSystemComponent>(prefabEntity))
         {
-            auto& particlesComp = m_Registry.get<ParticlesSystemComponent>(prefabEntity);
+            const auto& particlesComp = m_Registry.get<ParticlesSystemComponent>(prefabEntity);
             entity.AddComponent<ParticlesSystemComponent>(particlesComp);
         }
 

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -47,6 +47,7 @@ namespace Coffee {
         CopyComponentToPrefab<AudioZoneComponent>(sourceEntity, destEntity);
         CopyComponentToPrefab<NavMeshComponent>(sourceEntity, destEntity);
         CopyComponentToPrefab<NavigationAgentComponent>(sourceEntity, destEntity);
+        CopyComponentToPrefab<SpriteComponent>(sourceEntity, destEntity);
         
         // Copy empty components (which don't need values)
         CopyEmptyComponentToPrefab<StaticComponent>(sourceEntity, destEntity);
@@ -186,6 +187,7 @@ namespace Coffee {
         CopyComponentToScene<AudioZoneComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<NavigationAgentComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<NavMeshComponent>(scene, prefabEntity, entity);
+        CopyComponentToScene<SpriteComponent>(scene, prefabEntity, entity);
         
         // Copy empty components
         CopyEmptyComponentToScene<StaticComponent>(scene, prefabEntity, entity);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -56,6 +56,27 @@ namespace Coffee {
         if (sourceEntity.HasComponent<ActiveComponent>())
             m_Registry.emplace<ActiveComponent>(destEntity);
 
+        if (sourceEntity.HasComponent<ScriptComponent>())
+            m_Registry.emplace<ScriptComponent>(destEntity, sourceEntity.GetComponent<ScriptComponent>());
+
+        if (sourceEntity.HasComponent<AnimatorComponent>())
+            m_Registry.emplace<AnimatorComponent>(destEntity, sourceEntity.GetComponent<AnimatorComponent>());
+
+        if (sourceEntity.HasComponent<AudioSourceComponent>())
+            m_Registry.emplace<AudioSourceComponent>(destEntity, sourceEntity.GetComponent<AudioSourceComponent>());
+
+        if (sourceEntity.HasComponent<AudioListenerComponent>())
+            m_Registry.emplace<AudioListenerComponent>(destEntity, sourceEntity.GetComponent<AudioListenerComponent>());
+
+        if (sourceEntity.HasComponent<AudioZoneComponent>())
+            m_Registry.emplace<AudioZoneComponent>(destEntity, sourceEntity.GetComponent<AudioZoneComponent>());
+
+        if (sourceEntity.HasComponent<NavMeshComponent>())
+            m_Registry.emplace<NavMeshComponent>(destEntity, sourceEntity.GetComponent<NavMeshComponent>());
+
+        if (sourceEntity.HasComponent<NavigationAgentComponent>())
+            m_Registry.emplace<NavigationAgentComponent>(destEntity, sourceEntity.GetComponent<NavigationAgentComponent>());
+
         std::vector<Entity> children = sourceEntity.GetChildren();
         for (auto& child : children)
         {

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -149,6 +149,54 @@ namespace Coffee {
             entity.AddComponent<ParticlesSystemComponent>(particlesComp);
         }
 
+        if (m_Registry.all_of<ScriptComponent>(prefabEntity))
+        {
+            auto& scriptComp = m_Registry.get<ScriptComponent>(prefabEntity);
+            entity.AddComponent<ScriptComponent>(scriptComp);
+        }
+
+        if (m_Registry.all_of<AnimatorComponent>(prefabEntity))
+        {
+            auto& animatorComp = m_Registry.get<AnimatorComponent>(prefabEntity);
+            entity.AddComponent<AnimatorComponent>(animatorComp);
+        }
+
+        if (m_Registry.all_of<AudioSourceComponent>(prefabEntity))
+        {
+            auto& audioSourceComp = m_Registry.get<AudioSourceComponent>(prefabEntity);
+            entity.AddComponent<AudioSourceComponent>(audioSourceComp);
+        }
+
+        if (m_Registry.all_of<AudioListenerComponent>(prefabEntity))
+        {
+            auto& audioListenerComp = m_Registry.get<AudioListenerComponent>(prefabEntity);
+            entity.AddComponent<AudioListenerComponent>(audioListenerComp);
+        }
+
+        if (m_Registry.all_of<AudioZoneComponent>(prefabEntity))
+        {
+            auto& audioZoneComp = m_Registry.get<AudioZoneComponent>(prefabEntity);
+            entity.AddComponent<AudioZoneComponent>(audioZoneComp);
+        }
+
+        if (m_Registry.all_of<NavigationAgentComponent>(prefabEntity))
+        {
+            auto& navAgentComp = m_Registry.get<NavigationAgentComponent>(prefabEntity);
+            entity.AddComponent<NavigationAgentComponent>(navAgentComp);
+        }
+
+        if (m_Registry.all_of<NavMeshComponent>(prefabEntity))
+        {
+            auto& navMeshComp = m_Registry.get<NavMeshComponent>(prefabEntity);
+            entity.AddComponent<NavMeshComponent>(navMeshComp);
+        }
+
+        if (m_Registry.all_of<ParticlesSystemComponent>(prefabEntity))
+        {
+            auto& particlesComp = m_Registry.get<ParticlesSystemComponent>(prefabEntity);
+            entity.AddComponent<ParticlesSystemComponent>(particlesComp);
+        }
+
         if (m_Registry.all_of<StaticComponent>(prefabEntity))
         {
             entity.AddComponent<StaticComponent>();

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
@@ -26,6 +26,31 @@ namespace Coffee {
         static Ref<Prefab> Load(const std::filesystem::path& path);
         
     private:
+        // Helper templates to simplify component copying
+        template<typename T>
+        void CopyComponentToPrefab(Entity source, entt::entity dest) {
+            if (source.HasComponent<T>())
+                m_Registry.emplace<T>(dest, source.GetComponent<T>());
+        }
+        
+        template<typename T>
+        void CopyEmptyComponentToPrefab(Entity source, entt::entity dest) {
+            if (source.HasComponent<T>())
+                m_Registry.emplace<T>(dest);
+        }
+        
+        template<typename T>
+        void CopyComponentToScene(Scene* scene, entt::entity source, Entity& dest) {
+            if (m_Registry.all_of<T>(source))
+                dest.AddComponent<T>(m_Registry.get<T>(source));
+        }
+        
+        template<typename T>
+        void CopyEmptyComponentToScene(Scene* scene, entt::entity source, Entity& dest) {
+            if (m_Registry.all_of<T>(source))
+                dest.AddComponent<T>();
+        }
+        
         entt::entity CopyEntityToPrefab(Entity sourceEntity, entt::entity parentEntity = entt::null);
         Entity CopyEntityToScene(Scene* scene, entt::entity prefabEntity, Entity parent);
         

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
@@ -36,6 +36,19 @@ namespace Coffee {
         {
             archive(cereal::make_nvp("Base", cereal::base_class<Resource>(this)));
             archive(cereal::make_nvp("RootEntity", m_RootEntity));
+
+            entt::snapshot{m_Registry}
+                .get<entt::entity>(archive)
+                .template get<TagComponent>(archive)
+                .template get<TransformComponent>(archive)
+                .template get<HierarchyComponent>(archive)
+                .template get<MeshComponent>(archive)
+                .template get<MaterialComponent>(archive)
+                .template get<LightComponent>(archive)
+                .template get<RigidbodyComponent>(archive)
+                .template get<ParticlesSystemComponent>(archive)
+                .template get<StaticComponent>(archive)
+                .template get<ActiveComponent>(archive);
         }
         
         template<class Archive>
@@ -43,6 +56,19 @@ namespace Coffee {
         {
             archive(cereal::make_nvp("Base", cereal::base_class<Resource>(this)));
             archive(cereal::make_nvp("RootEntity", m_RootEntity));
+
+            entt::snapshot_loader{m_Registry}
+                .get<entt::entity>(archive)
+                .template get<TagComponent>(archive)
+                .template get<TransformComponent>(archive)
+                .template get<HierarchyComponent>(archive)
+                .template get<MeshComponent>(archive)
+                .template get<MaterialComponent>(archive)
+                .template get<LightComponent>(archive)
+                .template get<RigidbodyComponent>(archive)
+                .template get<ParticlesSystemComponent>(archive)
+                .template get<StaticComponent>(archive)
+                .template get<ActiveComponent>(archive);
         }
         
     private:

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
@@ -81,7 +81,8 @@ namespace Coffee {
                 .template get<AudioListenerComponent>(archive)
                 .template get<AudioZoneComponent>(archive)
                 .template get<NavMeshComponent>(archive)
-                .template get<NavigationAgentComponent>(archive);
+                .template get<NavigationAgentComponent>(archive)
+                .template get<SpriteComponent>(archive);
         }
         
         template<class Archive>
@@ -108,7 +109,8 @@ namespace Coffee {
                 .template get<AudioListenerComponent>(archive)
                 .template get<AudioZoneComponent>(archive)
                 .template get<NavMeshComponent>(archive)
-                .template get<NavigationAgentComponent>(archive);
+                .template get<NavigationAgentComponent>(archive)
+                .template get<SpriteComponent>(archive);
 
             SceneManager::GetActiveScene()->AssignAnimatorsToMeshes(AnimationSystem::GetAnimators());
 

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
@@ -48,7 +48,14 @@ namespace Coffee {
                 .template get<RigidbodyComponent>(archive)
                 .template get<ParticlesSystemComponent>(archive)
                 .template get<StaticComponent>(archive)
-                .template get<ActiveComponent>(archive);
+                .template get<ActiveComponent>(archive)
+                .template get<ScriptComponent>(archive)
+                .template get<AnimatorComponent>(archive)
+                .template get<AudioSourceComponent>(archive)
+                .template get<AudioListenerComponent>(archive)
+                .template get<AudioZoneComponent>(archive)
+                .template get<NavMeshComponent>(archive)
+                .template get<NavigationAgentComponent>(archive);
         }
         
         template<class Archive>
@@ -68,7 +75,14 @@ namespace Coffee {
                 .template get<RigidbodyComponent>(archive)
                 .template get<ParticlesSystemComponent>(archive)
                 .template get<StaticComponent>(archive)
-                .template get<ActiveComponent>(archive);
+                .template get<ActiveComponent>(archive)
+                .template get<ScriptComponent>(archive)
+                .template get<AnimatorComponent>(archive)
+                .template get<AudioSourceComponent>(archive)
+                .template get<AudioListenerComponent>(archive)
+                .template get<AudioZoneComponent>(archive)
+                .template get<NavMeshComponent>(archive)
+                .template get<NavigationAgentComponent>(archive);
         }
         
     private:

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.h
@@ -5,6 +5,7 @@
 #include "CoffeeEngine/IO/Resource.h"
 #include "CoffeeEngine/Scene/Entity.h"
 #include "CoffeeEngine/Scene/Scene.h"
+#include "SceneManager.h"
 
 #include <entt/entt.hpp>
 #include <filesystem>
@@ -83,6 +84,9 @@ namespace Coffee {
                 .template get<AudioZoneComponent>(archive)
                 .template get<NavMeshComponent>(archive)
                 .template get<NavigationAgentComponent>(archive);
+
+            SceneManager::GetActiveScene()->AssignAnimatorsToMeshes(AnimationSystem::GetAnimators());
+
         }
         
     private:

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -64,6 +64,24 @@ namespace Coffee {
     }
 
     template <>
+    void CopyComponentIfExists<ActiveComponent>(entt::entity destinyEntity, entt::entity sourceEntity, entt::registry& registry)
+    {
+        // ActiveComponent is empty, just place it
+        if (!registry.all_of<ActiveComponent>(destinyEntity)) {
+            registry.emplace<ActiveComponent>(destinyEntity);
+        }
+    }
+
+    template <>
+    void CopyComponentIfExists<StaticComponent>(entt::entity destinyEntity, entt::entity sourceEntity, entt::registry& registry)
+    {
+        // StaticComponent is empty, just place it
+        if (!registry.all_of<StaticComponent>(destinyEntity)) {
+            registry.emplace<StaticComponent>(destinyEntity);
+        }
+    }
+
+    template <>
     void CopyComponentIfExists<HierarchyComponent>(entt::entity destinyEntity, entt::entity sourceEntity, entt::registry& registry)
     {
         // We don't need to copy the hierarchy component directly

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
@@ -208,7 +208,11 @@ namespace Coffee {
 
     private:
         // NOTE: this macro should be modified when adding new components
-        #define ALL_COMPONENTS TagComponent, TransformComponent, HierarchyComponent, CameraComponent, MeshComponent, MaterialComponent, LightComponent, RigidbodyComponent, ScriptComponent, AudioSourceComponent, AudioListenerComponent, AudioZoneComponent, ParticlesSystemComponent, AnimatorComponent
+        #define ALL_COMPONENTS \
+            TagComponent, TransformComponent, HierarchyComponent, CameraComponent, \
+            MeshComponent, MaterialComponent, LightComponent, RigidbodyComponent, \
+            ScriptComponent, AudioSourceComponent, AudioListenerComponent, AudioZoneComponent, \
+            ParticlesSystemComponent, AnimatorComponent, ActiveComponent, StaticComponent
 
         entt::registry m_Registry;
         Scope<SceneTree> m_SceneTree;


### PR DESCRIPTION
This pull request introduces support for Prefabs. Users can now right-click an entity in the Scene Tree Panel to open a contextual menu, which provides the option to create a `.prefab` file. These prefab files can be loaded via Lua scripts or by dragging and dropping them from the Content Browser.

Currently, there is a known issue when hovering over a prefab in the Content Browser. The Resource Manager logs an error indicating that the resource is not registered in the registry. This behavior is expected since prefabs are loaded directly from disk. However, due to the current implementation of the Content Browser, loading a resource from disk without workarounds is not straightforward. A cleaner approach for implementing drag-and-drop functionality and resource management could address this limitation in the future.