### PR TITLE
Static Frustum Culling using Octree

### DIFF
--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -604,18 +604,28 @@ namespace Coffee
             bool isStatic = entity.HasComponent<StaticComponent>();
             if (ImGui::Checkbox("Static", &isStatic))
             {
+                auto children = entity.GetChildren();
                 if (isStatic)
                 {
                     if (!entity.HasComponent<StaticComponent>())
                         entity.AddComponent<StaticComponent>();
 
-                    // Open a modal to ask if the use wants to apply the static component to all children
-                    ImGui::OpenPopup("Apply Static to Children");
+                    if (children.size() > 0)
+                    {
+                        // Open a modal to ask if the use wants to apply the static component to all children
+                        ImGui::OpenPopup("Apply Static to Children");
+                    }
                 }
                 else
                 {
                     if (entity.HasComponent<StaticComponent>())
                         entity.RemoveComponent<StaticComponent>();
+
+                    if (children.size() > 0)
+                    {
+                        // Open a modal to ask if the use wants to remove the static component to all children
+                        ImGui::OpenPopup("Remove Static Children");
+                    }
                 }
             }
 
@@ -642,6 +652,39 @@ namespace Coffee
                     };
                 
                     SetStaticRecursively(entity);
+
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("No"))
+                {
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::EndPopup();
+            }
+
+            if (ImGui::BeginPopupModal("Remove Static Children", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+            {
+                ImGui::Text("Do you want to remove the static component from all children?");
+                ImGui::Separator();
+                ImGui::Text("This will remove static component from all children.");
+                ImGui::Separator();
+
+                if (ImGui::Button("Yes"))
+                {
+                    std::function<void(Entity)> RemoveStaticRecursively = [&](Entity currentEntity) {
+                        if (currentEntity.HasComponent<StaticComponent>())
+                            currentEntity.RemoveComponent<StaticComponent>();
+
+                        // Recursively handle children
+                        auto children = currentEntity.GetChildren();
+                        for (auto& child : children)
+                        {
+                            RemoveStaticRecursively(child);
+                        }
+                    };
+
+                    RemoveStaticRecursively(entity);
 
                     ImGui::CloseCurrentPopup();
                 }

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -529,12 +529,49 @@ namespace Coffee
                 {
                     if (!entity.HasComponent<StaticComponent>())
                         entity.AddComponent<StaticComponent>();
+
+                    // Open a modal to ask if the use wants to apply the static component to all children
+                    ImGui::OpenPopup("Apply Static to Children");
                 }
                 else
                 {
                     if (entity.HasComponent<StaticComponent>())
                         entity.RemoveComponent<StaticComponent>();
                 }
+            }
+
+            // Modal for applying static to children
+            if (ImGui::BeginPopupModal("Apply Static to Children", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+            {
+                ImGui::Text("Do you want to apply the static component to all children?");
+                ImGui::Separator();
+                ImGui::Text("This will make all children static as well.");
+                ImGui::Separator();
+
+                if (ImGui::Button("Yes"))
+                {
+                    std::function<void(Entity)> SetStaticRecursively = [&](Entity currentEntity) {
+                        if (!currentEntity.HasComponent<StaticComponent>())
+                            currentEntity.AddComponent<StaticComponent>();
+                
+                        // Recursively handle children
+                        auto children = currentEntity.GetChildren();
+                        for (auto& child : children)
+                        {
+                            SetStaticRecursively(child);
+                        }
+                    };
+                
+                    SetStaticRecursively(entity);
+
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("No"))
+                {
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::EndPopup();
             }
         
             ImGui::Separator();

--- a/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
@@ -24,6 +24,7 @@ namespace Coffee {
     public:
         AABB aabb;
         bool isLeaf = true;
+        int depth = 0; // Depth of the node in the octree
         std::vector<int> objectIDs; // Store only object IDs
         std::array<Scope<OctreeNode>, 8> children;
 
@@ -102,7 +103,7 @@ namespace Coffee {
     void Octree<T>::InsertIntoLeaf(OctreeNode<T>& node, int objectID)
     {
         node.objectIDs.push_back(objectID);
-        if (node.objectIDs.size() > maxObjectsPerNode && maxDepth > 0)
+        if (node.objectIDs.size() > maxObjectsPerNode && node.depth < maxDepth)
         {
             Subdivide(node);
             RedistributeObjects(node);
@@ -164,6 +165,7 @@ namespace Coffee {
             // Create a new child node and set its AABB
             node.children[i] = CreateScope<OctreeNode<T>>();
             node.children[i]->aabb = AABB(childMin, childMax);
+            node.children[i]->depth = node.depth + 1;
         }
     }
 

--- a/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
@@ -221,7 +221,7 @@ namespace Coffee {
 
             for (int id : objectIDs)
             {
-                const ObjectContainer<T>& obj = objectMap.at(id);
+                const ObjectContainer<T>& obj = *objectMap.at(id);
                 AABB aabb = obj.aabb.CalculateTransformedAABB(obj.transform);
                 Renderer2D::DrawBox(aabb.min, aabb.max, glm::vec4(0.0f, 1.0f, 0.0f, 1.0f));
             }

--- a/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
@@ -85,6 +85,7 @@ namespace Coffee {
     template <typename T>
     void Octree<T>::DebugDraw()
     {
+        ZoneScoped;
         rootNode.DebugDrawAABB(objectMap);
     }
 

--- a/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
@@ -12,9 +12,9 @@ namespace Coffee {
     template <typename T>
     struct ObjectContainer
     {
-        const glm::mat4& transform;
-        const AABB& aabb;
-        const T& object;
+        const glm::mat4 transform;
+        const AABB aabb;
+        const T object;
         mutable int id; //REMOVE
     };
 
@@ -27,7 +27,7 @@ namespace Coffee {
         std::vector<int> objectIDs; // Store only object IDs
         std::array<Scope<OctreeNode>, 8> children;
 
-        void DebugDrawAABB();
+        void DebugDrawAABB(const std::unordered_map<int, Ref<ObjectContainer<T>>>& objectMap);
     };
 
     template <typename T>
@@ -38,7 +38,7 @@ namespace Coffee {
         Octree(const AABB& bounds, int maxObjectsPerNode = 8, int maxDepth = 5);
         ~Octree();
 
-        void Insert(const Ref<ObjectContainer<T>>& object);
+        void Insert(Ref<ObjectContainer<T>> object);
         void DebugDraw();
         void Clear();
 
@@ -62,11 +62,17 @@ namespace Coffee {
     };
 
     template <typename T>
-    void Octree<T>::Insert(const Ref<ObjectContainer<T>>& object)
+    void Octree<T>::Insert(Ref<ObjectContainer<T>> object)
     {
         object->id = objectsCounter++;
         objectMap[object->id] = object; // Store in centralized map
         Insert(rootNode, object->id);
+    }
+
+    template <typename T>
+    void Octree<T>::DebugDraw()
+    {
+        rootNode.DebugDrawAABB(objectMap);
     }
 
     template <typename T>
@@ -201,32 +207,30 @@ namespace Coffee {
     }
 
     template <typename T>
-    void OctreeNode<T>::DebugDrawAABB()
+    void OctreeNode<T>::DebugDrawAABB(const std::unordered_map<int, Ref<ObjectContainer<T>>>& objectMap)
     {
-/*         int numObjects = objectIDs.size();
+            int numObjects = objectIDs.size();
 
-        float green = glm::clamp(numObjects / 10.0f, 0.0f, 1.0f);
-        float red = glm::clamp(1.0f - (numObjects / 10.0f), 0.0f, 1.0f);
-        glm::vec4 color(red, green, 0.0f, 1.0f);
+            float green = glm::clamp(numObjects / 10.0f, 0.0f, 1.0f);
+            float red = glm::clamp(1.0f - (numObjects / 10.0f), 0.0f, 1.0f);
+            glm::vec4 color(red, green, 0.0f, 1.0f);
 
-        Renderer2D::DrawBox(aabb.min, aabb.max, color);
-        if (!isLeaf)
-        {
-            for (auto& child : children)
+            Renderer2D::DrawBox(aabb.min, aabb.max, color);
+
+            for (int id : objectIDs)
+            {
+                const ObjectContainer<T>& obj = objectMap.at(id);
+                AABB aabb = obj.aabb.CalculateTransformedAABB(obj.transform);
+                Renderer2D::DrawBox(aabb.min, aabb.max, glm::vec4(0.0f, 1.0f, 0.0f, 1.0f));
+            }
+
+            for (const auto& child : children)
             {
                 if (child)
                 {
-                    child->DebugDrawAABB();
+                    child->DebugDrawAABB(objectMap);
                 }
             }
-        }
-
-        for (int id : objectIDs)
-        {
-            const ObjectContainer<T>& obj = objectMap.at(id);
-            AABB aabb = obj.aabb.CalculateTransformedAABB(obj.transform);
-            Renderer2D::DrawBox(aabb.min, aabb.max, glm::vec4(0.0f, 1.0f, 0.0f, 1.0f));
-        } */
     }
 
     template <typename T>

--- a/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
@@ -17,6 +17,7 @@ namespace Coffee {
         const glm::mat4& transform;
         const AABB& aabb;
         const T& object;
+        mutable int id;
     };
 
     template <typename T>
@@ -29,7 +30,7 @@ namespace Coffee {
         std::array<Scope<OctreeNode>, 8> children;
 
         void DebugDrawAABB();
-        int GetChildIndex(const AABB& bounds, const glm::vec3& point) const;
+
     };
 
     template <typename T>
@@ -44,7 +45,8 @@ namespace Coffee {
         void DebugDraw();
         void Clear();
 
-        std::vector<ObjectContainer<T>> Query(const Frustum& frustum) const;
+        std::unordered_map<int, ObjectContainer<T>> Query(const Frustum& frustum) const;
+
 
     private:
         void Insert(OctreeNode<T>& node, const ObjectContainer<T>& object);
@@ -54,11 +56,13 @@ namespace Coffee {
         void Subdivide(OctreeNode<T>& node);
         void CreateChildren(OctreeNode<T>& node, const glm::vec3& center);
 
-        void Query(const OctreeNode<T>& node, const Frustum& frustum, std::vector<ObjectContainer<T>>& results) const;
+        void Query(const OctreeNode<T>& node, const Frustum& frustum,
+                   std::unordered_map<int, ObjectContainer<T>>& results) const;
 
         OctreeNode<T> rootNode;
         int maxObjectsPerNode;
         int maxDepth;
+        int objectsCounter = 0;
     };
 
     template <typename T>
@@ -93,23 +97,37 @@ namespace Coffee {
         }
     }
 
-    template <typename T>
-    void Octree<T>::InsertIntoChild(OctreeNode<T>& node, const ObjectContainer<T>& object) {
-        int childIndex = node.GetChildIndex(node.aabb, object.transform[3]);
-        Insert(*node.children[childIndex], object);
+    template <typename T> 
+    void Octree<T>::InsertIntoChild(OctreeNode<T>& node, const ObjectContainer<T>& object)
+    {
+        for (auto& child : node.children)
+        {
+            if (!child)
+                continue;
+            if (child->aabb.Intersect(object.aabb.CalculateTransformedAABB(object.transform)) !=
+                IntersectionType::Outside)
+            {
+                Insert(*child, object);
+            }
+        }
+
     }
 
     template <typename T>
-    void Octree<T>::RedistributeObjects(OctreeNode<T>& node) {
-        for (const auto& obj : node.objectList) {
-            int childIndex = node.GetChildIndex(node.aabb, obj.transform[3]);
-            Insert(*node.children[childIndex], obj);
+    void Octree<T>::RedistributeObjects(OctreeNode<T>& node)
+    {
+        for (const auto& obj : node.objectList)
+        {
+            InsertIntoChild(node, obj);
         }
         node.objectList.clear();
     }
 
     template <typename T>
-    void Octree<T>::Insert(const ObjectContainer<T>& object) {
+    void Octree<T>::Insert(const ObjectContainer<T>& object)
+    {
+        object.id = objectsCounter;
+        objectsCounter++;
         Insert(rootNode, object);
     }
 
@@ -122,25 +140,27 @@ namespace Coffee {
     }
 
     template <typename T>
-    void Octree<T>::CreateChildren(OctreeNode<T>& node, const glm::vec3& center) {
+    void Octree<T>::CreateChildren(OctreeNode<T>& node, const glm::vec3& center)
+    {
         node.children[0] = CreateScope<OctreeNode<T>>(AABB(node.aabb.min, center));
         node.children[1] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(center.x, node.aabb.min.y, node.aabb.min.z),
-                                                        glm::vec3(node.aabb.max.x, center.y, center.z)));
+                                                           glm::vec3(node.aabb.max.x, center.y, center.z)));
         node.children[2] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(node.aabb.min.x, center.y, node.aabb.min.z),
-                                                        glm::vec3(center.x, node.aabb.max.y, center.z)));
+                                                           glm::vec3(center.x, node.aabb.max.y, center.z)));
         node.children[3] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(center.x, center.y, node.aabb.min.z),
-                                                        glm::vec3(node.aabb.max.x, node.aabb.max.y, center.z)));
+                                                           glm::vec3(node.aabb.max.x, node.aabb.max.y, center.z)));
         node.children[4] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(node.aabb.min.x, node.aabb.min.y, center.z),
-                                                        glm::vec3(center.x, center.y, node.aabb.max.z)));
+                                                           glm::vec3(center.x, center.y, node.aabb.max.z)));
         node.children[5] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(center.x, node.aabb.min.y, center.z),
-                                                        glm::vec3(node.aabb.max.x, center.y, node.aabb.max.z)));
+                                                           glm::vec3(node.aabb.max.x, center.y, node.aabb.max.z)));
         node.children[6] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(node.aabb.min.x, center.y, center.z),
-                                                        glm::vec3(center.x, node.aabb.max.y, node.aabb.max.z)));
+                                                           glm::vec3(center.x, node.aabb.max.y, node.aabb.max.z)));
         node.children[7] = CreateScope<OctreeNode<T>>(AABB(center, node.aabb.max));
     }
 
     template <typename T>
-    void Octree<T>::Query(const OctreeNode<T>& node, const Frustum& frustum, std::vector<ObjectContainer<T>>& results) const
+    void Octree<T>::Query(const OctreeNode<T>& node, const Frustum& frustum,
+                          std::unordered_map<int, ObjectContainer<T>>& results) const
     {
         if (!frustum.Contains(node.aabb))
             return;
@@ -148,7 +168,9 @@ namespace Coffee {
         for (const auto& object : node.objectList)
         {
             if (frustum.Contains(object.aabb.CalculateTransformedAABB(object.transform)))
-                results.push_back(object);
+            {
+                results.emplace(object.id, object); // Evita duplicados usando el id como clave
+            }
         }
 
         if (node.isLeaf)
@@ -195,18 +217,8 @@ namespace Coffee {
     }
 
     template <typename T>
-    int OctreeNode<T>::GetChildIndex(const AABB& bounds, const glm::vec3& point) const
-    {
-        glm::vec3 center = (bounds.min + bounds.max) * 0.5f;
-        int index = 0;
-        if (point.x > center.x) index |= 1;
-        if (point.y > center.y) index |= 2;
-        if (point.z > center.z) index |= 4;
-        return index;
-    }
-
-    template <typename T>
-    Octree<T>::Octree(const AABB& bounds, int maxObjectsPerNode, int maxDepth) : maxObjectsPerNode(maxObjectsPerNode), maxDepth(maxDepth)
+    Octree<T>::Octree(const AABB& bounds, int maxObjectsPerNode, int maxDepth)
+        : maxObjectsPerNode(maxObjectsPerNode), maxDepth(maxDepth)
     {
         rootNode.aabb = bounds;
     }
@@ -237,9 +249,9 @@ namespace Coffee {
     }
 
     template <typename T>
-    std::vector<ObjectContainer<T>> Octree<T>::Query(const Frustum& frustum) const
+    std::unordered_map<int, ObjectContainer<T>> Octree<T>::Query(const Frustum& frustum) const
     {
-        std::vector<ObjectContainer<T>> results;
+        std::unordered_map<int, ObjectContainer<T>> results;
         Query(rootNode, frustum, results);
         return results;
     }

--- a/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/DataStructures/Octree.h
@@ -4,10 +4,8 @@
 #include "CoffeeEngine/Math/BoundingBox.h"
 #include "CoffeeEngine/Math/Frustum.h"
 #include "CoffeeEngine/Renderer/Renderer2D.h"
-#include "CoffeeEngine/Renderer/Mesh.h"
+#include <unordered_map>
 #include <vector>
-#include <memory>
-#include "CoffeeEngine/Renderer/Renderer2D.h"
 
 namespace Coffee {
 
@@ -17,7 +15,7 @@ namespace Coffee {
         const glm::mat4& transform;
         const AABB& aabb;
         const T& object;
-        mutable int id;
+        mutable int id; //REMOVE
     };
 
     template <typename T>
@@ -26,11 +24,10 @@ namespace Coffee {
     public:
         AABB aabb;
         bool isLeaf = true;
-        std::vector<ObjectContainer<T>> objectList;
+        std::vector<int> objectIDs; // Store only object IDs
         std::array<Scope<OctreeNode>, 8> children;
 
         void DebugDrawAABB();
-
     };
 
     template <typename T>
@@ -41,34 +38,41 @@ namespace Coffee {
         Octree(const AABB& bounds, int maxObjectsPerNode = 8, int maxDepth = 5);
         ~Octree();
 
-        void Insert(const ObjectContainer<T>& object);
+        void Insert(const Ref<ObjectContainer<T>>& object);
         void DebugDraw();
         void Clear();
 
-        std::unordered_map<int, ObjectContainer<T>> Query(const Frustum& frustum) const;
-
+        std::vector<T> Query(const Frustum& frustum) const;
 
     private:
-        void Insert(OctreeNode<T>& node, const ObjectContainer<T>& object);
-        void InsertIntoLeaf(OctreeNode<T>& node, const ObjectContainer<T>& object);
-        void InsertIntoChild(OctreeNode<T>& node, const ObjectContainer<T>& object);
+        void Insert(OctreeNode<T>& node, int objectID);
+        void InsertIntoLeaf(OctreeNode<T>& node, int objectID);
+        void InsertIntoChild(OctreeNode<T>& node, int objectID);
         void RedistributeObjects(OctreeNode<T>& node);
         void Subdivide(OctreeNode<T>& node);
         void CreateChildren(OctreeNode<T>& node, const glm::vec3& center);
 
-        void Query(const OctreeNode<T>& node, const Frustum& frustum,
-                   std::unordered_map<int, ObjectContainer<T>>& results) const;
+        void Query(const OctreeNode<T>& node, const Frustum& frustum, std::vector<T>& results) const;
 
         OctreeNode<T> rootNode;
         int maxObjectsPerNode;
         int maxDepth;
         int objectsCounter = 0;
+        std::unordered_map<int, Ref<ObjectContainer<T>>> objectMap; // Centralized storage
     };
 
     template <typename T>
-    void Octree<T>::Insert(OctreeNode<T>& node, const ObjectContainer<T>& object)
+    void Octree<T>::Insert(const Ref<ObjectContainer<T>>& object)
     {
-        AABB objectTransformedAABB = object.aabb.CalculateTransformedAABB(object.transform);
+        object->id = objectsCounter++;
+        objectMap[object->id] = object; // Store in centralized map
+        Insert(rootNode, object->id);
+    }
+
+    template <typename T>
+    void Octree<T>::Insert(OctreeNode<T>& node, int objectID)
+    {
+        AABB objectTransformedAABB = objectMap.at(objectID)->aabb.CalculateTransformedAABB(objectMap.at(objectID)->transform);
 
         switch (node.aabb.Intersect(objectTransformedAABB))
         {
@@ -79,103 +83,102 @@ namespace Coffee {
             case Intersect:
                 if (node.isLeaf)
                 {
-                    InsertIntoLeaf(node, object);
+                    InsertIntoLeaf(node, objectID);
                 }
                 else
                 {
-                    InsertIntoChild(node, object);
+                    InsertIntoChild(node, objectID);
                 }
         }
     }
 
     template <typename T>
-    void Octree<T>::InsertIntoLeaf(OctreeNode<T>& node, const ObjectContainer<T>& object) {
-        node.objectList.push_back(object);
-        if (node.objectList.size() > maxObjectsPerNode && maxDepth > 0) {
+    void Octree<T>::InsertIntoLeaf(OctreeNode<T>& node, int objectID)
+    {
+        node.objectIDs.push_back(objectID);
+        if (node.objectIDs.size() > maxObjectsPerNode && maxDepth > 0)
+        {
             Subdivide(node);
             RedistributeObjects(node);
         }
     }
 
-    template <typename T> 
-    void Octree<T>::InsertIntoChild(OctreeNode<T>& node, const ObjectContainer<T>& object)
+    template <typename T>
+    void Octree<T>::InsertIntoChild(OctreeNode<T>& node, int objectID)
     {
         for (auto& child : node.children)
         {
             if (!child)
                 continue;
-            if (child->aabb.Intersect(object.aabb.CalculateTransformedAABB(object.transform)) !=
+            if (child->aabb.Intersect(objectMap.at(objectID)->aabb.CalculateTransformedAABB(objectMap.at(objectID)->transform)) !=
                 IntersectionType::Outside)
             {
-                Insert(*child, object);
+                Insert(*child, objectID);
             }
         }
-
     }
 
     template <typename T>
     void Octree<T>::RedistributeObjects(OctreeNode<T>& node)
     {
-        for (const auto& obj : node.objectList)
+        for (int id : node.objectIDs)
         {
-            InsertIntoChild(node, obj);
+            InsertIntoChild(node, id);
         }
-        node.objectList.clear();
-    }
-
-    template <typename T>
-    void Octree<T>::Insert(const ObjectContainer<T>& object)
-    {
-        object.id = objectsCounter;
-        objectsCounter++;
-        Insert(rootNode, object);
+        node.objectIDs.clear();
     }
 
     template <typename T>
     void Octree<T>::Subdivide(OctreeNode<T>& node)
     {
-        glm::vec3 center = (node.aabb.min + node.aabb.max) * 0.5f;
-        CreateChildren(node, center);
-        node.isLeaf = false;
+        if (!node.isLeaf)
+            return; // If the node is not a leaf, no need to subdivide
+
+        glm::vec3 center = node.aabb.GetCenter(); // Calculate the center of the node's AABB
+        CreateChildren(node, center);            // Create child nodes
+        node.isLeaf = false;                     // Mark the node as no longer a leaf
     }
 
     template <typename T>
     void Octree<T>::CreateChildren(OctreeNode<T>& node, const glm::vec3& center)
     {
-        node.children[0] = CreateScope<OctreeNode<T>>(AABB(node.aabb.min, center));
-        node.children[1] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(center.x, node.aabb.min.y, node.aabb.min.z),
-                                                           glm::vec3(node.aabb.max.x, center.y, center.z)));
-        node.children[2] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(node.aabb.min.x, center.y, node.aabb.min.z),
-                                                           glm::vec3(center.x, node.aabb.max.y, center.z)));
-        node.children[3] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(center.x, center.y, node.aabb.min.z),
-                                                           glm::vec3(node.aabb.max.x, node.aabb.max.y, center.z)));
-        node.children[4] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(node.aabb.min.x, node.aabb.min.y, center.z),
-                                                           glm::vec3(center.x, center.y, node.aabb.max.z)));
-        node.children[5] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(center.x, node.aabb.min.y, center.z),
-                                                           glm::vec3(node.aabb.max.x, center.y, node.aabb.max.z)));
-        node.children[6] = CreateScope<OctreeNode<T>>(AABB(glm::vec3(node.aabb.min.x, center.y, center.z),
-                                                           glm::vec3(center.x, node.aabb.max.y, node.aabb.max.z)));
-        node.children[7] = CreateScope<OctreeNode<T>>(AABB(center, node.aabb.max));
+        const glm::vec3& min = node.aabb.min;
+        const glm::vec3& max = node.aabb.max;
+
+        for (int i = 0; i < 8; ++i)
+        {
+            glm::vec3 childMin = min;
+            glm::vec3 childMax = max;
+
+            // Adjust the min and max coordinates for each child based on the center
+            if (i & 1) childMin.x = center.x; else childMax.x = center.x;
+            if (i & 2) childMin.y = center.y; else childMax.y = center.y;
+            if (i & 4) childMin.z = center.z; else childMax.z = center.z;
+
+            // Create a new child node and set its AABB
+            node.children[i] = CreateScope<OctreeNode<T>>();
+            node.children[i]->aabb = AABB(childMin, childMax);
+        }
     }
 
     template <typename T>
-    void Octree<T>::Query(const OctreeNode<T>& node, const Frustum& frustum,
-                          std::unordered_map<int, ObjectContainer<T>>& results) const
+    void Octree<T>::Query(const OctreeNode<T>& node, const Frustum& frustum, std::vector<T>& results) const
     {
         if (!frustum.Contains(node.aabb))
             return;
-
-        for (const auto& object : node.objectList)
+    
+        for (int id : node.objectIDs)
         {
-            if (frustum.Contains(object.aabb.CalculateTransformedAABB(object.transform)))
+            const Ref<ObjectContainer<T>>& object = objectMap.at(id);
+            if (frustum.Contains(object->aabb.CalculateTransformedAABB(object->transform)))
             {
-                results.emplace(object.id, object); // Evita duplicados usando el id como clave
+                results.push_back(object->object);
             }
         }
-
+    
         if (node.isLeaf)
             return;
-
+    
         for (const auto& child : node.children)
         {
             if (child)
@@ -186,17 +189,26 @@ namespace Coffee {
     }
 
     template <typename T>
+    Octree<T>::Octree(const AABB& bounds, int maxObjectsPerNode, int maxDepth) : maxObjectsPerNode(maxObjectsPerNode), maxDepth(maxDepth)
+    {
+        rootNode.aabb = bounds;
+    }
+
+    template <typename T>
+    Octree<T>::~Octree()
+    {
+        Clear();
+    }
+
+    template <typename T>
     void OctreeNode<T>::DebugDrawAABB()
     {
-        // Assuming you have a function to get the number of objects in the node
-        int numObjects = objectList.size();
+/*         int numObjects = objectIDs.size();
 
-        // Calculate the color based on the number of objects
         float green = glm::clamp(numObjects / 10.0f, 0.0f, 1.0f);
         float red = glm::clamp(1.0f - (numObjects / 10.0f), 0.0f, 1.0f);
         glm::vec4 color(red, green, 0.0f, 1.0f);
 
-        // Draw the box with the calculated color
         Renderer2D::DrawBox(aabb.min, aabb.max, color);
         if (!isLeaf)
         {
@@ -209,49 +221,34 @@ namespace Coffee {
             }
         }
 
-        for (auto& obj : objectList)
+        for (int id : objectIDs)
         {
+            const ObjectContainer<T>& obj = objectMap.at(id);
             AABB aabb = obj.aabb.CalculateTransformedAABB(obj.transform);
             Renderer2D::DrawBox(aabb.min, aabb.max, glm::vec4(0.0f, 1.0f, 0.0f, 1.0f));
-        }
-    }
-
-    template <typename T>
-    Octree<T>::Octree(const AABB& bounds, int maxObjectsPerNode, int maxDepth)
-        : maxObjectsPerNode(maxObjectsPerNode), maxDepth(maxDepth)
-    {
-        rootNode.aabb = bounds;
-    }
-
-    template <typename T>
-    Octree<T>::~Octree()
-    {
-        Clear();
-    }
-
-    template <typename T>
-    void Octree<T>::DebugDraw()
-    {
-        rootNode.DebugDrawAABB();
+        } */
     }
 
     template <typename T>
     void Octree<T>::Clear()
     {
-        rootNode.objectList.clear();
-        for (auto& child : rootNode.children) {
-            if (child) {
-                child->objectList.clear();
+        rootNode.objectIDs.clear();
+        for (auto& child : rootNode.children)
+        {
+            if (child)
+            {
+                child->objectIDs.clear();
                 child.reset();
             }
         }
         rootNode.isLeaf = true;
+        objectMap.clear(); // Clear centralized storage
     }
 
     template <typename T>
-    std::unordered_map<int, ObjectContainer<T>> Octree<T>::Query(const Frustum& frustum) const
+    std::vector<T> Octree<T>::Query(const Frustum& frustum) const
     {
-        std::unordered_map<int, ObjectContainer<T>> results;
+        std::vector<T> results;
         Query(rootNode, frustum, results);
         return results;
     }

--- a/CoffeeEngine/src/CoffeeEngine/Physics/CollisionSystem.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Physics/CollisionSystem.cpp
@@ -13,6 +13,8 @@ namespace Coffee {
 
     void CollisionSystem::checkCollisions(const PhysicsWorld& world) {
 
+        ZoneScoped;
+
         std::unordered_set<std::pair<btCollisionObject*, btCollisionObject*>, PairHash> currentCollisions;
 
         int numManifolds = world.getDynamicsWorld()->getDispatcher()->getNumManifolds();

--- a/CoffeeEngine/src/CoffeeEngine/Physics/PhysicsWorld.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Physics/PhysicsWorld.cpp
@@ -45,6 +45,7 @@ namespace Coffee {
     }
 
     void PhysicsWorld::stepSimulation(const float dt) const {
+        ZoneScoped;
         dynamicsWorld->stepSimulation(dt);
         CollisionSystem::checkCollisions(*this);
     }
@@ -64,6 +65,7 @@ namespace Coffee {
 
     void PhysicsWorld::drawCollisionShapes() const
     {
+        ZoneScoped;
         if (!dynamicsWorld)
             return;
         const int numCollisionObjects = dynamicsWorld->getNumCollisionObjects();

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -58,7 +58,7 @@ namespace Coffee {
 
     }
 
-    Scene::Scene() : m_Octree({glm::vec3(-150.0f), glm::vec3(150.0f)}, 10, 5)
+    Scene::Scene()
     {
         m_SceneTree = CreateScope<SceneTree>(this);
 
@@ -344,8 +344,40 @@ namespace Coffee {
 
         CollisionSystem::Initialize(this);
 
-        // Static entities octree
         auto staticView = m_Registry.view<StaticComponent, TransformComponent>();
+
+        // Create octree bounds based on the static entities
+        glm::vec3 minOctreeBounds = glm::vec3(0.0f);
+        glm::vec3 maxOctreeBounds = glm::vec3(0.0f);
+
+        for (auto entity : staticView)
+        {
+            auto& transformComponent = staticView.get<TransformComponent>(entity);
+            auto meshComponent = m_Registry.try_get<MeshComponent>(entity);
+
+            AABB aabb;
+
+            if(meshComponent)
+            {
+                Ref<Mesh> mesh = meshComponent->GetMesh();
+                aabb = mesh->GetAABB();
+            }
+            else
+            {
+                aabb = AABB(glm::vec3(-0.5f), glm::vec3(0.5f));
+            }
+
+            AABB transformedAABB = aabb.CalculateTransformedAABB(transformComponent.GetWorldTransform());
+
+            minOctreeBounds = glm::min(minOctreeBounds, transformedAABB.min);
+            maxOctreeBounds = glm::max(maxOctreeBounds, transformedAABB.max);
+
+
+        }
+
+        m_Octree = CreateScope<Octree<entt::entity>>(AABB(minOctreeBounds, maxOctreeBounds), 10, 5);
+
+        // Static entities octree
         for (auto entity : staticView)
         {
             auto& transformComponent = staticView.get<TransformComponent>(entity);
@@ -364,7 +396,7 @@ namespace Coffee {
             }
 
             Ref<ObjectContainer<entt::entity>> object = CreateRef<ObjectContainer<entt::entity>>(transformComponent.GetWorldTransform(), aabb, entity);
-            m_Octree.Insert(object);
+            m_Octree->Insert(object);
         }
 
         Audio::StopAllEvents();
@@ -534,7 +566,7 @@ namespace Coffee {
         }
 
         // Debug Draw
-        if (m_SceneDebugFlags.ShowOctree) m_Octree.DebugDraw();
+        if (m_SceneDebugFlags.ShowOctree) m_Octree->DebugDraw();
         if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
         if (m_SceneDebugFlags.ShowNavMesh) {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
@@ -659,7 +691,7 @@ namespace Coffee {
 
         // Get all the static entities from the Octree
         Frustum frustum = Frustum(camera->GetProjection() * glm::inverse(cameraTransform));
-        auto visibleStaticEntities = m_Octree.Query(frustum);
+        auto visibleStaticEntities = m_Octree->Query(frustum);
         std::unordered_set<entt::entity> visibleEntitySet(visibleStaticEntities.begin(), visibleStaticEntities.end());
 
         auto staticView = m_Registry.view<StaticComponent>();
@@ -786,7 +818,7 @@ namespace Coffee {
         }
 
         // Debug Draw
-        if (m_SceneDebugFlags.ShowOctree) m_Octree.DebugDraw();
+        if (m_SceneDebugFlags.ShowOctree) m_Octree->DebugDraw();
         if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
         if (m_SceneDebugFlags.ShowNavMesh) {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -2,7 +2,6 @@
 
 #include "CoffeeEngine/Core/Base.h"
 #include "CoffeeEngine/Core/DataStructures/Octree.h"
-#include "CoffeeEngine/Core/Input.h"
 #include "CoffeeEngine/Core/Log.h"
 #include "CoffeeEngine/Math/Frustum.h"
 #include "CoffeeEngine/Physics/Collider.h"
@@ -20,12 +19,11 @@
 #include "CoffeeEngine/Scene/SceneCamera.h"
 #include "CoffeeEngine/Scene/SceneManager.h"
 #include "CoffeeEngine/Scene/SceneTree.h"
+#include <CoffeeEngine/Scripting/Script.h>
 #include "CoffeeEngine/Scripting/Lua/LuaScript.h"
 #include "CoffeeEngine/UI/UIManager.h"
-#include "PrimitiveMesh.h"
 #include "entt/entity/entity.hpp"
 #include "entt/entity/fwd.hpp"
-#include "entt/entity/snapshot.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -35,7 +33,6 @@
 #include <string>
 #include <tracy/Tracy.hpp>
 
-#include <CoffeeEngine/Scripting/Script.h>
 #include <cereal/archives/json.hpp>
 #include <fstream>
 
@@ -327,17 +324,28 @@ namespace Coffee {
 
         CollisionSystem::Initialize(this);
 
-/*         auto view = m_Registry.view<MeshComponent>();
-
-        for (auto& entity : view)
+        // Static entities octree
+        auto staticView = m_Registry.view<StaticComponent, TransformComponent>();
+        for (auto entity : staticView)
         {
-            auto& meshComponent = view.get<MeshComponent>(entity);
-            auto& transformComponent = m_Registry.get<TransformComponent>(entity);
+            auto& transformComponent = staticView.get<TransformComponent>(entity);
+            auto meshComponent = m_Registry.try_get<MeshComponent>(entity);
 
-            ObjectContainer<Ref<Mesh>> objectContainer = {transformComponent.GetWorldTransform(), meshComponent.GetMesh()->GetAABB(), meshComponent.GetMesh()};
+            AABB aabb;
 
-            m_Octree.Insert(objectContainer);
-        } */
+            if(meshComponent)
+            {
+                Ref<Mesh> mesh = meshComponent->GetMesh();
+                aabb = mesh->GetAABB();
+            }
+            else
+            {
+                aabb = AABB(glm::vec3(-0.5f), glm::vec3(0.5f));
+            }
+
+            Ref<ObjectContainer<entt::entity>> object = CreateRef<ObjectContainer<entt::entity>>(transformComponent.GetWorldTransform(), aabb, entity);
+            m_Octree.Insert(object);
+        }
 
         Audio::StopAllEvents();
         Audio::PlayInitialAudios();
@@ -531,10 +539,76 @@ namespace Coffee {
             }
         }
 
+        // TODO: Ask to Guillem if this is a candidate for frustum culling
         UpdateAudioComponentsPositions();
 
+        //======== STATIC ENTITIES UPDATE ========//
+
+        // Get all the static entities from the Octree
+
+        Frustum frustum = Frustum(camera->GetProjection() * glm::inverse(cameraTransform));
+
+        auto staticEntities = m_Octree.Query(frustum);
+
+        for (auto& e : staticEntities)
+        {
+            auto entity = Entity{e, this};
+            auto& transformComponent = m_Registry.get<TransformComponent>(entity);
+
+            //Animator update
+            auto animatorComponent = m_Registry.try_get<AnimatorComponent>(entity);
+            if (animatorComponent)
+            {
+                AnimationSystem::Update(dt, animatorComponent);
+            }
+
+            // Mesh Rendering
+            auto meshComponent = m_Registry.try_get<MeshComponent>(entity);
+            auto materialComponent = m_Registry.try_get<MaterialComponent>(entity);
+
+            if(meshComponent)
+            {
+                Ref<Mesh> mesh = meshComponent->GetMesh();
+                Ref<Material> material = (materialComponent) ? materialComponent->material : nullptr;
+
+                Renderer3D::Submit(RenderCommand{transformComponent.GetWorldTransform(), mesh, material, (uint32_t)entity, meshComponent->animator});
+            }
+
+            // Light Rendering
+            auto lightComponent = m_Registry.try_get<LightComponent>(entity);
+            if(lightComponent)
+            {
+                lightComponent->Position = transformComponent.GetWorldTransform()[3];
+                lightComponent->Direction = glm::normalize(glm::vec3(-transformComponent.GetWorldTransform()[1]));
+
+                Renderer3D::Submit(*lightComponent);
+            }
+
+            // Script Updating
+            auto scriptComponent = m_Registry.try_get<ScriptComponent>(entity);
+            if (scriptComponent)
+            {
+                scriptComponent->script->OnUpdate(dt);
+                if(SceneManager::GetActiveScene().get() != this)
+                    return;
+            }
+
+            auto spriteComponent = m_Registry.try_get<SpriteComponent>(entity);
+            if (spriteComponent)
+            {
+                if (spriteComponent->texture)
+                {
+                    Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), spriteComponent->texture,
+                                         spriteComponent->tilingFactor, spriteComponent->tintColor,
+                                         Renderer2D::RenderMode::World);
+                }
+            }
+        }
+
+        //======== DYNAMIC ENTITIES UPDATE ========//
+
         // Get all entities with ScriptComponent
-        auto scriptView = m_Registry.view<ActiveComponent, ScriptComponent>();
+        auto scriptView = m_Registry.view<ActiveComponent, ScriptComponent>(entt::exclude<StaticComponent>);
 
         for (auto& entity : scriptView)
         {
@@ -550,23 +624,7 @@ namespace Coffee {
         //TODO: Add this to a function bc it is repeated in OnUpdateEditor
         Renderer::GetCurrentRenderTarget()->SetCamera(*camera, cameraTransform);
 
-        //m_Octree.DebugDraw();
-
-        // Get all the static meshes from the Octree
-/*
-        glm::mat4 testProjection = glm::perspective(glm::radians(90.0f), 16.0f / 9.0f, 0.1f, 100.0f);
-
-        Frustum frustum = Frustum(camera->GetProjection() * glm::inverse(cameraTransform));
-        Renderer2D::DrawFrustum(frustum, glm::vec4(1.0f), 1.0f);
-
-        auto meshes = m_Octree.Query(frustum);
-
-        for(auto& mesh : meshes)
-        {
-            Renderer::Submit(RenderCommand{mesh.transform, mesh.object, mesh.object->GetMaterial(), 0});
-        } */
-
-        auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>();
+        auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>(entt::exclude<StaticComponent>);
 
         for (auto& entity : animatorView)
         {
@@ -575,7 +633,7 @@ namespace Coffee {
         }
 
         // Get all entities with ModelComponent and TransformComponent
-        auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>();
+        auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>(entt::exclude<StaticComponent>);
 
         // Loop through each entity with the specified components
         for (auto& entity : view)
@@ -593,7 +651,7 @@ namespace Coffee {
         }
 
         //Get all entities with LightComponent and TransformComponent
-        auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>();
+        auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>(entt::exclude<StaticComponent>);
 
         //Loop through each entity with the specified components
         for(auto& entity : lightView)
@@ -608,7 +666,7 @@ namespace Coffee {
         }
 
         // Get all entities with ParticlesSystemComponent and TransformComponent
-        auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>();
+        auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>(entt::exclude<StaticComponent>);
         for (auto& entity : particleSystemView)
         {
             auto& particlesSystemComponent = particleSystemView.get<ParticlesSystemComponent>(entity);
@@ -620,7 +678,7 @@ namespace Coffee {
 
         }
 
-        auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>();
+        auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>(entt::exclude<StaticComponent>);
         for (auto& entity : spriteView)
         {
             auto& spriteComponent = spriteView.get<SpriteComponent>(entity);
@@ -631,8 +689,6 @@ namespace Coffee {
                                      spriteComponent.tilingFactor, spriteComponent.tintColor,
                                      Renderer2D::RenderMode::World);
             }
-
-            
         }
 
         UIManager::UpdateUI(m_Registry);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -395,119 +395,151 @@ namespace Coffee {
         Renderer::GetCurrentRenderTarget()->SetCamera(camera, glm::inverse(camera.GetViewMatrix()));
 
         // TEMPORAL - Navigation
-        auto navMeshView = m_Registry.view<ActiveComponent, NavMeshComponent>();
-
-        for (auto& entity : navMeshView)
         {
-            auto& navMeshComponent = navMeshView.get<NavMeshComponent>(entity);
-            if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated())
+            auto navMeshView = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            ZoneScopedN("NavMeshComponent View");
+
+            for (auto& entity : navMeshView)
             {
-                navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                auto& navMeshComponent = navMeshView.get<NavMeshComponent>(entity);
+                if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() &&
+                    navMeshComponent.GetNavMesh()->IsCalculated())
+                {
+                    navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                }
             }
         }
 
 
-        auto viewRigidbody = m_Registry.view<ActiveComponent, RigidbodyComponent, TransformComponent>();
-
-        for (auto entity : viewRigidbody) {
-            auto [rb, transform] = viewRigidbody.get<RigidbodyComponent, TransformComponent>(entity);
-            if (rb.rb) {
-                rb.rb->SetPosition(transform.GetLocalPosition());
-                rb.rb->SetRotation(transform.GetLocalRotation());
-            }
-        }
-
-        auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>();
-
-        for (auto& entity : animatorView)
         {
-            AnimatorComponent* animatorComponent = &animatorView.get<AnimatorComponent>(entity);
-            if (animatorComponent->NeedsUpdate)
+            auto viewRigidbody = m_Registry.view<ActiveComponent, RigidbodyComponent, TransformComponent>();
+            ZoneScopedN("RigidbodyComponent View");
+
+            for (auto entity : viewRigidbody)
             {
-                AnimationSystem::Update(dt, animatorComponent);
-                animatorComponent->NeedsUpdate = false;
+                auto [rb, transform] = viewRigidbody.get<RigidbodyComponent, TransformComponent>(entity);
+                if (rb.rb)
+                {
+                    rb.rb->SetPosition(transform.GetLocalPosition());
+                    rb.rb->SetRotation(transform.GetLocalRotation());
+                }
             }
         }
 
-        UpdateAudioComponentsPositions();
-
-        // Get all entities with ModelComponent and TransformComponent
-        auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>();
-
-        // Loop through each entity with the specified components
-        for (auto& entity : view)
         {
-            // Get the ModelComponent and TransformComponent for the current entity
-            auto& meshComponent = view.get<MeshComponent>(entity);
-            auto& transformComponent = view.get<TransformComponent>(entity);
-            auto materialComponent = m_Registry.try_get<MaterialComponent>(entity);
+            auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>();
+            ZoneScopedN("AnimatorComponent View");
 
-            Ref<Mesh> mesh = meshComponent.GetMesh();
-            Ref<Material> material = (materialComponent) ? materialComponent->material : nullptr;
-
-            //Renderer::Submit(material, mesh, transformComponent.GetWorldTransform(), (uint32_t)entity);
-            Renderer3D::Submit(RenderCommand{transformComponent.GetWorldTransform(), mesh, material, (uint32_t)entity, meshComponent.animator});
-        }
-
-        //Get all entities with LightComponent and TransformComponent
-        auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>();
-
-        //Loop through each entity with the specified components
-        for(auto& entity : lightView)
-        {
-            auto& lightComponent = lightView.get<LightComponent>(entity);
-            auto& transformComponent = lightView.get<TransformComponent>(entity);
-
-            lightComponent.Position = transformComponent.GetWorldTransform()[3];
-            lightComponent.Direction = glm::normalize(glm::vec3(-transformComponent.GetWorldTransform()[1]));
-
-            Renderer3D::Submit(lightComponent);
-        }
-
-
-        // Get all entities with ParticlesSystemComponent and TransformComponent
-        auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>();
-        for (auto& entity : particleSystemView)
-        {
-            auto& particlesSystemComponent = particleSystemView.get<ParticlesSystemComponent>(entity);
-            auto& transformComponent = particleSystemView.get<TransformComponent>(entity);
-            if (particlesSystemComponent.NeedsUpdate)
+            for (auto& entity : animatorView)
             {
-                particlesSystemComponent.NeedsUpdate = false;
-                particlesSystemComponent.GetParticleEmitter()->transformComponentMatrix = transformComponent.GetWorldTransform();
-                particlesSystemComponent.GetParticleEmitter()->cameraViewMatrix = camera.GetViewMatrix();
-                particlesSystemComponent.GetParticleEmitter()->Update(dt);
-                particlesSystemComponent.GetParticleEmitter()->DrawDebug();
+                AnimatorComponent* animatorComponent = &animatorView.get<AnimatorComponent>(entity);
+                if (animatorComponent->NeedsUpdate)
+                {
+                    AnimationSystem::Update(dt, animatorComponent);
+                    animatorComponent->NeedsUpdate = false;
+                }
             }
-            else {
-                Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), 
-                    particlesSystemComponent.GetParticleEmitter()->particleTexture, 1, 
-                    particlesSystemComponent.GetParticleEmitter()->colorNormal, Renderer2D::RenderMode::World);
-            }
- 
         }
 
-        auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>();
-        for (auto& entity : spriteView)
         {
-            auto& spriteComponent = spriteView.get<SpriteComponent>(entity);
-            auto& transformComponent = spriteView.get<TransformComponent>(entity);
+            ZoneScopedN("UpdateAudioComponentsPositions");
+            UpdateAudioComponentsPositions();
+        }
 
-            if (spriteComponent.texture)
+        {
+            // Get all entities with ModelComponent and TransformComponent
+            auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>();
+            ZoneScopedN("MeshComponent View");
+
+            // Loop through each entity with the specified components
+            for (auto& entity : view)
             {
-                Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), spriteComponent.texture,
-                                     spriteComponent.tilingFactor, spriteComponent.tintColor,
-                                     Renderer2D::RenderMode::World);
+                // Get the ModelComponent and TransformComponent for the current entity
+                auto& meshComponent = view.get<MeshComponent>(entity);
+                auto& transformComponent = view.get<TransformComponent>(entity);
+                auto materialComponent = m_Registry.try_get<MaterialComponent>(entity);
+
+                Ref<Mesh> mesh = meshComponent.GetMesh();
+                Ref<Material> material = (materialComponent) ? materialComponent->material : nullptr;
+
+                //Renderer::Submit(material, mesh, transformComponent.GetWorldTransform(), (uint32_t)entity);
+                Renderer3D::Submit(RenderCommand{transformComponent.GetWorldTransform(), mesh, material, (uint32_t)entity, meshComponent.animator});
             }
         }
 
-        UIManager::UpdateUI(m_Registry);
+        {
+            //Get all entities with LightComponent and TransformComponent
+            auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>();
+            ZoneScopedN("LightComponent View");
+
+            //Loop through each entity with the specified components
+            for(auto& entity : lightView)
+            {
+                auto& lightComponent = lightView.get<LightComponent>(entity);
+                auto& transformComponent = lightView.get<TransformComponent>(entity);
+
+                lightComponent.Position = transformComponent.GetWorldTransform()[3];
+                lightComponent.Direction = glm::normalize(glm::vec3(-transformComponent.GetWorldTransform()[1]));
+
+                Renderer3D::Submit(lightComponent);
+            }
+        }
+
+        {
+            // Get all entities with ParticlesSystemComponent and TransformComponent
+            auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>();
+            ZoneScopedN("ParticlesSystemComponent View");
+
+            for (auto& entity : particleSystemView)
+            {
+                auto& particlesSystemComponent = particleSystemView.get<ParticlesSystemComponent>(entity);
+                auto& transformComponent = particleSystemView.get<TransformComponent>(entity);
+                if (particlesSystemComponent.NeedsUpdate)
+                {
+                    particlesSystemComponent.NeedsUpdate = false;
+                    particlesSystemComponent.GetParticleEmitter()->transformComponentMatrix = transformComponent.GetWorldTransform();
+                    particlesSystemComponent.GetParticleEmitter()->cameraViewMatrix = camera.GetViewMatrix();
+                    particlesSystemComponent.GetParticleEmitter()->Update(dt);
+                    particlesSystemComponent.GetParticleEmitter()->DrawDebug();
+                }
+                else {
+                    Renderer2D::DrawQuad(transformComponent.GetWorldTransform(),
+                        particlesSystemComponent.GetParticleEmitter()->particleTexture, 1,
+                        particlesSystemComponent.GetParticleEmitter()->colorNormal, Renderer2D::RenderMode::World);
+                }
+            }
+        }
+
+        {
+            auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>();
+            ZoneScopedN("SpriteComponent View");
+
+            for (auto& entity : spriteView)
+            {
+                auto& spriteComponent = spriteView.get<SpriteComponent>(entity);
+                auto& transformComponent = spriteView.get<TransformComponent>(entity);
+
+                if (spriteComponent.texture)
+                {
+                    Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), spriteComponent.texture,
+                                         spriteComponent.tilingFactor, spriteComponent.tintColor,
+                                         Renderer2D::RenderMode::World);
+                }
+            }
+        }
+
+        {
+            ZoneScopedN("UIManager::UpdateUI");
+            UIManager::UpdateUI(m_Registry);
+        }
 
         // Debug Draw
         if (m_SceneDebugFlags.ShowOctree) m_Octree.DebugDraw();
         if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
         if (m_SceneDebugFlags.ShowNavMesh) {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            ZoneScopedN("NavMesh Debug View");
+
             for (auto& entity : navMeshViewDebug) {
                 auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
                 if (navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
@@ -516,6 +548,8 @@ namespace Coffee {
             }
         } else {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            ZoneScopedN("NavMesh Debug View - Disable");
+
             for (auto& entity : navMeshViewDebug) {
                 auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
                 navMeshComponent.ShowDebug = false;
@@ -524,6 +558,8 @@ namespace Coffee {
 
         if (m_SceneDebugFlags.ShowNavMeshPath) {
             auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            ZoneScopedN("NavigationAgent Debug View");
+
             for (auto& agent : navigationAgentViewDebug) {
                 auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
                 if (navAgentComponent.GetNavMeshComponent())
@@ -531,13 +567,14 @@ namespace Coffee {
             }
         } else {
             auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            ZoneScopedN("NavigationAgent Debug View - Disable");
+
             for (auto& agent : navigationAgentViewDebug) {
                 auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
                 navAgentComponent.ShowDebug = false;
             }
         }
     }
-
 
     void Scene::OnUpdateRuntime(float dt)
     {
@@ -547,17 +584,21 @@ namespace Coffee {
 
         Camera* camera = nullptr;
         glm::mat4 cameraTransform;
-        auto cameraView = m_Registry.view<ActiveComponent, TransformComponent, CameraComponent>();
-        for(auto entity : cameraView)
         {
-            auto [transform, cameraComponent] = cameraView.get<TransformComponent, CameraComponent>(entity);
+            auto cameraView = m_Registry.view<ActiveComponent, TransformComponent, CameraComponent>();
+            ZoneScopedN("CameraComponent View");
 
-            //TODO: Multiple cameras support (for now, the last camera found will be used)
-            camera = &cameraComponent.Camera;
-            cameraTransform = transform.GetWorldTransform();
+            for (auto entity : cameraView)
+            {
+                auto [transform, cameraComponent] = cameraView.get<TransformComponent, CameraComponent>(entity);
+
+                // TODO: Multiple cameras support (for now, the last camera found will be used)
+                camera = &cameraComponent.Camera;
+                cameraTransform = transform.GetWorldTransform();
+            }
         }
 
-        if(!camera)
+        if (!camera)
         {
             COFFEE_ERROR("No camera entity found!");
 
@@ -566,65 +607,79 @@ namespace Coffee {
 
             cameraTransform = glm::mat4(1.0f);
         }
-        
-        auto navMeshView = m_Registry.view<ActiveComponent, NavMeshComponent>();
 
-        for (auto& entity : navMeshView)
         {
-            auto& navMeshComponent = navMeshView.get<NavMeshComponent>(entity);
-            if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated())
+            auto navMeshView = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            ZoneScopedN("NavMeshComponent View");
+
+            for (auto& entity : navMeshView)
             {
-                navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                auto& navMeshComponent = navMeshView.get<NavMeshComponent>(entity);
+                if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated())
+                {
+                    navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                }
             }
         }
 
-        auto navigationAgentView = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
-
-        for (auto& agent : navigationAgentView)
         {
-            auto& navAgentComponent = navigationAgentView.get<NavigationAgentComponent>(agent);
-            if (navAgentComponent.ShowDebug && navAgentComponent.GetPathFinder())
-                navAgentComponent.GetPathFinder()->RenderPath(navAgentComponent.Path);
+            auto navigationAgentView = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            ZoneScopedN("NavigationAgentComponent View");
+
+            for (auto& agent : navigationAgentView)
+            {
+                auto& navAgentComponent = navigationAgentView.get<NavigationAgentComponent>(agent);
+                if (navAgentComponent.ShowDebug && navAgentComponent.GetPathFinder())
+                    navAgentComponent.GetPathFinder()->RenderPath(navAgentComponent.Path);
+            }
         }
 
         m_PhysicsWorld.stepSimulation(dt);
 
-        // Update transforms from physics
-        auto viewPhysics = m_Registry.view<ActiveComponent, RigidbodyComponent, TransformComponent>();
-        for (auto entity : viewPhysics) {
-            auto [rb, transform] = viewPhysics.get<RigidbodyComponent, TransformComponent>(entity);
-            if (rb.rb) {
-                transform.SetLocalPosition(rb.rb->GetPosition());
-                transform.SetLocalRotation(rb.rb->GetRotation());
+        {
+            // Update transforms from physics
+            auto viewPhysics = m_Registry.view<ActiveComponent, RigidbodyComponent, TransformComponent>();
+            ZoneScopedN("Physics Update View");
+
+            for (auto entity : viewPhysics) {
+                auto [rb, transform] = viewPhysics.get<RigidbodyComponent, TransformComponent>(entity);
+                if (rb.rb) {
+                    transform.SetLocalPosition(rb.rb->GetPosition());
+                    transform.SetLocalRotation(rb.rb->GetRotation());
+                }
             }
         }
 
-        // TODO: Ask to Guillem if this is a candidate for frustum culling
-        UpdateAudioComponentsPositions();
+        {
+            ZoneScopedN("UpdateAudioComponentsPositions");
+            // TODO: Ask to Guillem if this is a candidate for frustum culling
+            UpdateAudioComponentsPositions();
+        }
+
 
         // Get all the static entities from the Octree
-
         Frustum frustum = Frustum(camera->GetProjection() * glm::inverse(cameraTransform));
-
-        auto visibleStaticEntities  = m_Octree.Query(frustum);
-
+        auto visibleStaticEntities = m_Octree.Query(frustum);
         std::unordered_set<entt::entity> visibleEntitySet(visibleStaticEntities.begin(), visibleStaticEntities.end());
 
-
         auto staticView = m_Registry.view<StaticComponent>();
-
-        // Get all entities with ScriptComponent
-        auto scriptView = m_Registry.view<ActiveComponent, ScriptComponent>();
-
-        for (auto& entity : scriptView)
         {
-            /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
-                continue;*/
+            // Get all entities with ScriptComponent
+            auto scriptView = m_Registry.view<ActiveComponent, ScriptComponent>();
+            ZoneScopedN("ScriptComponent View");
 
-            auto& scriptComponent = scriptView.get<ScriptComponent>(entity);
-            scriptComponent.script->OnUpdate(dt);
-            if(SceneManager::GetActiveScene().get() != this)
-                return;
+            for (auto& entity : scriptView)
+            {
+                /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                    continue;*/
+
+                auto& scriptComponent = scriptView.get<ScriptComponent>(entity);
+                ZoneScoped;
+                ZoneText(scriptComponent.script->GetPath().filename().string().c_str(), scriptComponent.script->GetPath().filename().string().length());
+                scriptComponent.script->OnUpdate(dt);
+                if(SceneManager::GetActiveScene().get() != this)
+                    return;
+            }
         }
 
         if(SceneManager::GetActiveScene().get() != this)
@@ -633,86 +688,101 @@ namespace Coffee {
         //TODO: Add this to a function bc it is repeated in OnUpdateEditor
         Renderer::GetCurrentRenderTarget()->SetCamera(*camera, cameraTransform);
 
-        auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>();
-
-        for (auto& entity : animatorView)
         {
-            /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
-                continue;*/
+            auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>();
+            ZoneScopedN("AnimatorComponent View");
 
-            AnimatorComponent* animatorComponent = &animatorView.get<AnimatorComponent>(entity);
-            AnimationSystem::Update(dt, animatorComponent);
-        }
+            for (auto& entity : animatorView)
+            {
+                /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                    continue;*/
 
-        // Get all entities with ModelComponent and TransformComponent
-        auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>();
-
-        // Loop through each entity with the specified components
-        for (auto& entity : view)
-        {
-            if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
-                continue;
-
-            // Get the ModelComponent and TransformComponent for the current entity
-            auto& meshComponent = view.get<MeshComponent>(entity);
-            auto& transformComponent = view.get<TransformComponent>(entity);
-            auto materialComponent = m_Registry.try_get<MaterialComponent>(entity);
-
-            Ref<Mesh> mesh = meshComponent.GetMesh();
-            Ref<Material> material = (materialComponent) ? materialComponent->material : nullptr;
-
-            Renderer3D::Submit(RenderCommand{transformComponent.GetWorldTransform(), mesh, material, (uint32_t)entity, meshComponent.animator});
-        }
-
-        //Get all entities with LightComponent and TransformComponent
-        auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>();
-
-        //Loop through each entity with the specified components
-        for(auto& entity : lightView)
-        {
-            if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
-                continue;
-
-            auto& lightComponent = lightView.get<LightComponent>(entity);
-            auto& transformComponent = lightView.get<TransformComponent>(entity);
-
-            lightComponent.Position = transformComponent.GetWorldTransform()[3];
-            lightComponent.Direction = glm::normalize(glm::vec3(-transformComponent.GetWorldTransform()[1]));
-
-            Renderer3D::Submit(lightComponent);
-        }
-
-        // Get all entities with ParticlesSystemComponent and TransformComponent
-        auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>();
-        for (auto& entity : particleSystemView)
-        {
-            /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
-                continue;*/
-
-            auto& particlesSystemComponent = particleSystemView.get<ParticlesSystemComponent>(entity);
-            auto& transformComponent = particleSystemView.get<TransformComponent>(entity);
-
-            particlesSystemComponent.GetParticleEmitter()->transformComponentMatrix = transformComponent.GetWorldTransform();
-            particlesSystemComponent.GetParticleEmitter()->cameraViewMatrix = glm::inverse(cameraTransform);
-            particlesSystemComponent.GetParticleEmitter()->Update(dt);
-
-        }
-
-        auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>();
-        for (auto& entity : spriteView)
-        {
-            if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
-                continue;
-
-            auto& spriteComponent = spriteView.get<SpriteComponent>(entity);
-            auto& transformComponent = spriteView.get<TransformComponent>(entity);
-
-            if (spriteComponent.texture) {
-                Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), spriteComponent.texture,
-                                     spriteComponent.tilingFactor, spriteComponent.tintColor,
-                                     Renderer2D::RenderMode::World);
+                AnimatorComponent* animatorComponent = &animatorView.get<AnimatorComponent>(entity);
+                AnimationSystem::Update(dt, animatorComponent);
             }
+        }
 
+        {
+            // Get all entities with ModelComponent and TransformComponent
+            auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>();
+            ZoneScopedN("MeshComponent View");
+
+            // Loop through each entity with the specified components
+            for (auto& entity : view)
+            {
+                if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                    continue;
+
+                // Get the ModelComponent and TransformComponent for the current entity
+                auto& meshComponent = view.get<MeshComponent>(entity);
+                auto& transformComponent = view.get<TransformComponent>(entity);
+                auto materialComponent = m_Registry.try_get<MaterialComponent>(entity);
+
+                Ref<Mesh> mesh = meshComponent.GetMesh();
+                Ref<Material> material = (materialComponent) ? materialComponent->material : nullptr;
+
+                Renderer3D::Submit(RenderCommand{transformComponent.GetWorldTransform(), mesh, material, (uint32_t)entity, meshComponent.animator});
+            }
+        }
+
+        {
+            //Get all entities with LightComponent and TransformComponent
+            auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>();
+            ZoneScopedN("LightComponent View");
+
+            //Loop through each entity with the specified components
+            for(auto& entity : lightView)
+            {
+                if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                    continue;
+
+                auto& lightComponent = lightView.get<LightComponent>(entity);
+                auto& transformComponent = lightView.get<TransformComponent>(entity);
+
+                lightComponent.Position = transformComponent.GetWorldTransform()[3];
+                lightComponent.Direction = glm::normalize(glm::vec3(-transformComponent.GetWorldTransform()[1]));
+
+                Renderer3D::Submit(lightComponent);
+            }
+        }
+
+        {
+            // Get all entities with ParticlesSystemComponent and TransformComponent
+            auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>();
+            ZoneScopedN("ParticlesSystemComponent View");
+
+            for (auto& entity : particleSystemView)
+            {
+                /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                    continue;*/
+
+                auto& particlesSystemComponent = particleSystemView.get<ParticlesSystemComponent>(entity);
+                auto& transformComponent = particleSystemView.get<TransformComponent>(entity);
+
+                particlesSystemComponent.GetParticleEmitter()->transformComponentMatrix = transformComponent.GetWorldTransform();
+                particlesSystemComponent.GetParticleEmitter()->cameraViewMatrix = glm::inverse(cameraTransform);
+                particlesSystemComponent.GetParticleEmitter()->Update(dt);
+            }
+        }
+
+        {
+            auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>();
+            ZoneScopedN("SpriteComponent View");
+
+            for (auto& entity : spriteView)
+            {
+                if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                    continue;
+
+                auto& spriteComponent = spriteView.get<SpriteComponent>(entity);
+                auto& transformComponent = spriteView.get<TransformComponent>(entity);
+
+                if (spriteComponent.texture) {
+                    Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), spriteComponent.texture,
+                                         spriteComponent.tilingFactor, spriteComponent.tintColor,
+                                         Renderer2D::RenderMode::World);
+                }
+            }
         }
 
         // Debug Draw
@@ -720,6 +790,8 @@ namespace Coffee {
         if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
         if (m_SceneDebugFlags.ShowNavMesh) {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            ZoneScopedN("NavMesh Debug View");
+
             for (auto& entity : navMeshViewDebug) {
                 auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
                 if (navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
@@ -728,6 +800,8 @@ namespace Coffee {
             }
         } else {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            ZoneScopedN("NavMesh Debug View - Disable");
+
             for (auto& entity : navMeshViewDebug) {
                 auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
                 navMeshComponent.ShowDebug = false;
@@ -736,6 +810,8 @@ namespace Coffee {
 
         if (m_SceneDebugFlags.ShowNavMeshPath) {
             auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            ZoneScopedN("NavigationAgent Debug View");
+
             for (auto& agent : navigationAgentViewDebug) {
                 auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
                 if (navAgentComponent.GetNavMeshComponent())
@@ -743,6 +819,8 @@ namespace Coffee {
             }
         } else {
             auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            ZoneScopedN("NavigationAgent Debug View - Disable");
+
             for (auto& agent : navigationAgentViewDebug) {
                 auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
                 navAgentComponent.ShowDebug = false;
@@ -914,6 +992,8 @@ namespace Coffee {
     }
     void Scene::UpdateAudioComponentsPositions()
     {
+        ZoneScopedN("Scene::UpdateAudioComponentsPositions");
+
         auto audioSourceView = m_Registry.view<AudioSourceComponent, TransformComponent>();
 
         for (auto& entity : audioSourceView)

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -58,7 +58,7 @@ namespace Coffee {
 
     }
 
-    Scene::Scene() : m_Octree({glm::vec3(-50.0f), glm::vec3(50.0f)}, 10, 5)
+    Scene::Scene() : m_Octree({glm::vec3(-150.0f), glm::vec3(150.0f)}, 10, 5)
     {
         m_SceneTree = CreateScope<SceneTree>(this);
 
@@ -602,76 +602,25 @@ namespace Coffee {
         // TODO: Ask to Guillem if this is a candidate for frustum culling
         UpdateAudioComponentsPositions();
 
-        //======== STATIC ENTITIES UPDATE ========//
-
         // Get all the static entities from the Octree
 
         Frustum frustum = Frustum(camera->GetProjection() * glm::inverse(cameraTransform));
 
-        auto staticEntities = m_Octree.Query(frustum);
+        auto visibleStaticEntities  = m_Octree.Query(frustum);
 
-        for (auto& e : staticEntities)
-        {
-            auto entity = Entity{e, this};
-            auto& transformComponent = m_Registry.get<TransformComponent>(entity);
+        std::unordered_set<entt::entity> visibleEntitySet(visibleStaticEntities.begin(), visibleStaticEntities.end());
 
-            //Animator update
-            auto animatorComponent = m_Registry.try_get<AnimatorComponent>(entity);
-            if (animatorComponent)
-            {
-                AnimationSystem::Update(dt, animatorComponent);
-            }
 
-            // Mesh Rendering
-            auto meshComponent = m_Registry.try_get<MeshComponent>(entity);
-            auto materialComponent = m_Registry.try_get<MaterialComponent>(entity);
-
-            if(meshComponent)
-            {
-                Ref<Mesh> mesh = meshComponent->GetMesh();
-                Ref<Material> material = (materialComponent) ? materialComponent->material : nullptr;
-
-                Renderer3D::Submit(RenderCommand{transformComponent.GetWorldTransform(), mesh, material, (uint32_t)entity, meshComponent->animator});
-            }
-
-            // Light Rendering
-            auto lightComponent = m_Registry.try_get<LightComponent>(entity);
-            if(lightComponent)
-            {
-                lightComponent->Position = transformComponent.GetWorldTransform()[3];
-                lightComponent->Direction = glm::normalize(glm::vec3(-transformComponent.GetWorldTransform()[1]));
-
-                Renderer3D::Submit(*lightComponent);
-            }
-
-            // Script Updating
-            auto scriptComponent = m_Registry.try_get<ScriptComponent>(entity);
-            if (scriptComponent)
-            {
-                scriptComponent->script->OnUpdate(dt);
-                if(SceneManager::GetActiveScene().get() != this)
-                    return;
-            }
-
-            auto spriteComponent = m_Registry.try_get<SpriteComponent>(entity);
-            if (spriteComponent)
-            {
-                if (spriteComponent->texture)
-                {
-                    Renderer2D::DrawQuad(transformComponent.GetWorldTransform(), spriteComponent->texture,
-                                         spriteComponent->tilingFactor, spriteComponent->tintColor,
-                                         Renderer2D::RenderMode::World);
-                }
-            }
-        }
-
-        //======== DYNAMIC ENTITIES UPDATE ========//
+        auto staticView = m_Registry.view<StaticComponent>();
 
         // Get all entities with ScriptComponent
-        auto scriptView = m_Registry.view<ActiveComponent, ScriptComponent>(entt::exclude<StaticComponent>);
+        auto scriptView = m_Registry.view<ActiveComponent, ScriptComponent>();
 
         for (auto& entity : scriptView)
         {
+            /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                continue;*/
+
             auto& scriptComponent = scriptView.get<ScriptComponent>(entity);
             scriptComponent.script->OnUpdate(dt);
             if(SceneManager::GetActiveScene().get() != this)
@@ -684,20 +633,25 @@ namespace Coffee {
         //TODO: Add this to a function bc it is repeated in OnUpdateEditor
         Renderer::GetCurrentRenderTarget()->SetCamera(*camera, cameraTransform);
 
-        auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>(entt::exclude<StaticComponent>);
+        auto animatorView = m_Registry.view<ActiveComponent, AnimatorComponent>();
 
         for (auto& entity : animatorView)
         {
+            /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                continue;*/
+
             AnimatorComponent* animatorComponent = &animatorView.get<AnimatorComponent>(entity);
             AnimationSystem::Update(dt, animatorComponent);
         }
 
         // Get all entities with ModelComponent and TransformComponent
-        auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>(entt::exclude<StaticComponent>);
+        auto view = m_Registry.view<ActiveComponent, MeshComponent, TransformComponent>();
 
         // Loop through each entity with the specified components
         for (auto& entity : view)
         {
+            if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                continue;
 
             // Get the ModelComponent and TransformComponent for the current entity
             auto& meshComponent = view.get<MeshComponent>(entity);
@@ -711,11 +665,14 @@ namespace Coffee {
         }
 
         //Get all entities with LightComponent and TransformComponent
-        auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>(entt::exclude<StaticComponent>);
+        auto lightView = m_Registry.view<ActiveComponent, LightComponent, TransformComponent>();
 
         //Loop through each entity with the specified components
         for(auto& entity : lightView)
         {
+            if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                continue;
+
             auto& lightComponent = lightView.get<LightComponent>(entity);
             auto& transformComponent = lightView.get<TransformComponent>(entity);
 
@@ -726,9 +683,12 @@ namespace Coffee {
         }
 
         // Get all entities with ParticlesSystemComponent and TransformComponent
-        auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>(entt::exclude<StaticComponent>);
+        auto particleSystemView = m_Registry.view<ActiveComponent, ParticlesSystemComponent, TransformComponent>();
         for (auto& entity : particleSystemView)
         {
+            /*if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                continue;*/
+
             auto& particlesSystemComponent = particleSystemView.get<ParticlesSystemComponent>(entity);
             auto& transformComponent = particleSystemView.get<TransformComponent>(entity);
 
@@ -738,9 +698,12 @@ namespace Coffee {
 
         }
 
-        auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>(entt::exclude<StaticComponent>);
+        auto spriteView = m_Registry.view<ActiveComponent, SpriteComponent, TransformComponent>();
         for (auto& entity : spriteView)
         {
+            if (staticView.contains(entity) && visibleEntitySet.find(entity) == visibleEntitySet.end())
+                continue;
+
             auto& spriteComponent = spriteView.get<SpriteComponent>(entity);
             auto& transformComponent = spriteView.get<TransformComponent>(entity);
 

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -566,7 +566,7 @@ namespace Coffee {
         }
 
         // Debug Draw
-        if (m_SceneDebugFlags.ShowOctree) m_Octree->DebugDraw();
+        // if (m_SceneDebugFlags.ShowOctree) m_Octree->DebugDraw();
         if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
         if (m_SceneDebugFlags.ShowNavMesh) {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
@@ -307,7 +307,7 @@ namespace Coffee {
 
         entt::registry m_Registry;
         Scope<SceneTree> m_SceneTree;
-        Octree<entt::entity> m_Octree;
+        Scope<Octree<entt::entity>> m_Octree;
         PhysicsWorld m_PhysicsWorld;
         SceneDebugFlags m_SceneDebugFlags;
 

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
@@ -255,7 +255,7 @@ namespace Coffee {
 
         entt::registry m_Registry;
         Scope<SceneTree> m_SceneTree;
-        Octree<Ref<Mesh>> m_Octree;
+        Octree<entt::entity> m_Octree;
         PhysicsWorld m_PhysicsWorld;
 
         // Temporal: Scenes should be Resources and the Base Resource class already has a path variable.

--- a/CoffeeEngine/src/CoffeeEngine/Scene/SceneTree.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/SceneTree.cpp
@@ -268,6 +268,7 @@ namespace Coffee {
 
     void SceneTree::Update()
     {
+        ZoneScoped;
         auto& registry = m_Context->m_Registry;
         auto view = registry.view<TransformComponent, ActiveComponent>();
         for (auto entity : view) {


### PR DESCRIPTION
This pull request introduces two major updates: the addition of a modal for applying static components to child entities in the `SceneTreePanel` and a significant refactor of the `Octree` data structure to improve performance and scalability. Additionally, it implements frustum culling for static entities in the scene update logic, optimizing rendering by processing only visible objects.

### SceneTreePanel Enhancements:
* Added a modal popup to confirm applying the `StaticComponent` to all child entities. This includes recursive logic to apply the component to all descendants when the user selects "Yes." (`CoffeeEditor/Panels/SceneTreePanel.cpp`) [[1]](diffhunk://#diff-261f606e9d2f2dadf6d17fa21950d888b0e5f5ff11a409d842e740f0ee6926a7R532-R534) [[2]](diffhunk://#diff-261f606e9d2f2dadf6d17fa21950d888b0e5f5ff11a409d842e740f0ee6926a7R543-R576)

### Octree Refactor:
* Replaced the direct storage of `ObjectContainer` objects with centralized storage using an `unordered_map` of object IDs, reducing memory duplication and improving lookup efficiency. (`CoffeeEngine/Core/DataStructures/Octree.h`) [[1]](diffhunk://#diff-01c2f0ab9d2dcb3c994a4594dd5583dc9f0a50a2f443a075ebd9913471b52c36L7-R18) [[2]](diffhunk://#diff-01c2f0ab9d2dcb3c994a4594dd5583dc9f0a50a2f443a075ebd9913471b52c36L28-R31)
* Updated the `Octree` methods (`Insert`, `Query`, `RedistributeObjects`, etc.) to work with object IDs instead of full objects, streamlining operations. (`CoffeeEngine/Core/DataStructures/Octree.h`) [[1]](diffhunk://#diff-01c2f0ab9d2dcb3c994a4594dd5583dc9f0a50a2f443a075ebd9913471b52c36L43-R82) [[2]](diffhunk://#diff-01c2f0ab9d2dcb3c994a4594dd5583dc9f0a50a2f443a075ebd9913471b52c36L78-R184)
* Enhanced child node creation logic to dynamically calculate bounding boxes based on the node's center, improving code maintainability. (`CoffeeEngine/Core/DataStructures/Octree.h`)

### Scene Update Optimizations:
* Integrated frustum culling for static entities using the refactored `Octree`. Only entities within the camera's frustum are processed for rendering, animation, and script updates, significantly improving performance. (`CoffeeEngine/Scene/Scene.cpp`) [[1]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9L330-R348) [[2]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9R542-R611)
* Excluded `StaticComponent` entities from dynamic update loops (e.g., scripts, animations) to avoid redundant processing. (`CoffeeEngine/Scene/Scene.cpp`) [[1]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9L553-R627) [[2]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9L578-R636)

### Code Cleanup:
* Removed unused headers and legacy code, improving code readability and reducing build times. (`CoffeeEngine/Scene/Scene.cpp`) [[1]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9L5) [[2]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9R22-L28) [[3]](diffhunk://#diff-b0b647d95c67795ed492dd8b667f36404cba7303cfb8fc22b92e51ca4dae6ac9L38)