### PR TITLE
Material System Improvements

### DIFF
--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -884,6 +884,34 @@ namespace Coffee
                 {
                     MaterialTextures& materialTextures = materialComponent.material->GetMaterialTextures();
                     MaterialProperties& materialProperties = materialComponent.material->GetMaterialProperties();
+                    MaterialRenderSettings& materialRenderSettings = materialComponent.material->GetMaterialRenderSettings();
+
+                    if (ImGui::TreeNode("Render Settings"))
+                    {
+                        ImGui::BeginChild("##RenderSettings Child", {0, 0},
+                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+
+                        ImGui::Text("Transparency");
+                        ImGui::SameLine();
+                        ImGui::Combo("##Transparency", (int*)&materialRenderSettings.transparencyMode,
+                                     "Disabled\0Alpha\0AlphaCutoff\0");
+                        
+                        ImGui::Text("Cull Mode");
+                        ImGui::SameLine();
+                        ImGui::Combo("##CullMode", (int*)&materialRenderSettings.cullMode,
+                                     "Front\0Back\0None\0");
+
+                        ImGui::Text("Depth Test");
+                        ImGui::SameLine();
+                        ImGui::Checkbox("##DepthTest", &materialRenderSettings.depthTest);
+
+                        ImGui::Text("Wireframe");
+                        ImGui::SameLine();
+                        ImGui::Checkbox("##Wireframe", &materialRenderSettings.wireframe);
+
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
 
                     if (ImGui::TreeNode("Albedo"))
                     {

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -882,116 +882,121 @@ namespace Coffee
             {
                 if (ImGui::CollapsingHeader("Material", &isCollapsingHeaderOpen, ImGuiTreeNodeFlags_DefaultOpen))
                 {
-                    MaterialTextures& materialTextures = materialComponent.material->GetMaterialTextures();
-                    MaterialProperties& materialProperties = materialComponent.material->GetMaterialProperties();
-                    MaterialRenderSettings& materialRenderSettings = materialComponent.material->GetMaterialRenderSettings();
-
-                    if (ImGui::TreeNode("Render Settings"))
+                    if (materialComponent.material->GetType() == ResourceType::PBRMaterial)
                     {
-                        ImGui::BeginChild("##RenderSettings Child", {0, 0},
-                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                        PBRMaterial& pbrMaterial = *std::static_pointer_cast<PBRMaterial>(materialComponent.material);
 
-                        ImGui::Text("Transparency");
-                        ImGui::SameLine();
-                        ImGui::Combo("##Transparency", (int*)&materialRenderSettings.transparencyMode,
-                                     "Disabled\0Alpha\0AlphaCutoff\0");
-
-                        if (materialRenderSettings.transparencyMode == MaterialRenderSettings::TransparencyMode::AlphaCutoff)
+                        PBRMaterialTextures& materialTextures = pbrMaterial.GetTextures();
+                        PBRMaterialProperties& materialProperties = pbrMaterial.GetProperties();
+                        MaterialRenderSettings& materialRenderSettings = pbrMaterial.GetRenderSettings();
+    
+                        if (ImGui::TreeNode("Render Settings"))
                         {
-                            ImGui::Text("Alpha Cutoff");
+                            ImGui::BeginChild("##RenderSettings Child", {0, 0},
+                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+    
+                            ImGui::Text("Transparency");
                             ImGui::SameLine();
-                            ImGui::SliderFloat("##AlphaCutoff", &materialRenderSettings.alphaCutoff, 0.0f, 1.0f);
+                            ImGui::Combo("##Transparency", (int*)&materialRenderSettings.transparencyMode,
+                                         "Disabled\0Alpha\0AlphaCutoff\0");
+    
+                            if (materialRenderSettings.transparencyMode == MaterialRenderSettings::TransparencyMode::AlphaCutoff)
+                            {
+                                ImGui::Text("Alpha Cutoff");
+                                ImGui::SameLine();
+                                ImGui::SliderFloat("##AlphaCutoff", &materialRenderSettings.alphaCutoff, 0.0f, 1.0f);
+                            }
+                            
+                            ImGui::Text("Cull Mode");
+                            ImGui::SameLine();
+                            ImGui::Combo("##CullMode", (int*)&materialRenderSettings.cullMode,
+                                         "Front\0Back\0None\0");
+    
+                            ImGui::Text("Depth Test");
+                            ImGui::SameLine();
+                            ImGui::Checkbox("##DepthTest", &materialRenderSettings.depthTest);
+    
+                            ImGui::Text("Wireframe");
+                            ImGui::SameLine();
+                            ImGui::Checkbox("##Wireframe", &materialRenderSettings.wireframe);
+    
+                            ImGui::EndChild();
+                            ImGui::TreePop();
                         }
-                        
-                        ImGui::Text("Cull Mode");
-                        ImGui::SameLine();
-                        ImGui::Combo("##CullMode", (int*)&materialRenderSettings.cullMode,
-                                     "Front\0Back\0None\0");
-
-                        ImGui::Text("Depth Test");
-                        ImGui::SameLine();
-                        ImGui::Checkbox("##DepthTest", &materialRenderSettings.depthTest);
-
-                        ImGui::Text("Wireframe");
-                        ImGui::SameLine();
-                        ImGui::Checkbox("##Wireframe", &materialRenderSettings.wireframe);
-
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-
-                    if (ImGui::TreeNode("Albedo"))
-                    {
-                        ImGui::BeginChild("##Albedo Child", {0, 0},
-                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-
-                        ImGui::Text("Color");
-                        DrawCustomColorEdit4("##Albedo Color", materialProperties.color);
-
-                        ImGui::Text("Texture");
-                        DrawTextureWidget("##Albedo", materialTextures.albedo);
-
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-                    if (ImGui::TreeNode("Metallic"))
-                    {
-                        ImGui::BeginChild("##Metallic Child", {0, 0},
-                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                        ImGui::Text("Metallic");
-                        ImGui::SliderFloat("##Metallic Slider", &materialProperties.metallic, 0.0f, 1.0f);
-                        ImGui::Text("Texture");
-                        DrawTextureWidget("##Metallic", materialTextures.metallic);
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-                    if (ImGui::TreeNode("Roughness"))
-                    {
-                        ImGui::BeginChild("##Roughness Child", {0, 0},
-                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                        ImGui::Text("Roughness");
-                        ImGui::SliderFloat("##Roughness Slider", &materialProperties.roughness, 0.0f, 1.0f);
-                        ImGui::Text("Texture");
-                        DrawTextureWidget("##Roughness", materialTextures.roughness);
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-                    if (ImGui::TreeNode("Emission"))
-                    {
-                        ImGui::BeginChild("##Emission Child", {0, 0},
-                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                        // FIXME: Emissive color variable is local and do not affect the materialProperties.emissive!!
-                        glm::vec4& emissiveColor = reinterpret_cast<glm::vec4&>(materialProperties.emissive);
-                        emissiveColor.a = 1.0f;
-                        DrawCustomColorEdit4("Color", emissiveColor);
-                        ImGui::Text("Texture");
-                        DrawTextureWidget("##Emissive", materialTextures.emissive);
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-                    if (ImGui::TreeNode("Normal Map"))
-                    {
-                        ImGui::BeginChild("##Normal Child", {0, 0},
-                                          ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                        ImGui::Text("Texture");
-                        DrawTextureWidget("##Normal", materialTextures.normal);
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-                    if (ImGui::TreeNode("Ambient Occlusion"))
-                    {
-                        ImGui::BeginChild("##AO Child", {0, 0}, ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                        ImGui::Text("AO");
-                        ImGui::SliderFloat("##AO Slider", &materialProperties.ao, 0.0f, 1.0f);
-                        ImGui::Text("Texture");
-                        DrawTextureWidget("##AO", materialTextures.ao);
-                        ImGui::EndChild();
-                        ImGui::TreePop();
-                    }
-
-                    if (!isCollapsingHeaderOpen)
-                    {
-                        entity.RemoveComponent<MaterialComponent>();
+    
+                        if (ImGui::TreeNode("Albedo"))
+                        {
+                            ImGui::BeginChild("##Albedo Child", {0, 0},
+                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+    
+                            ImGui::Text("Color");
+                            DrawCustomColorEdit4("##Albedo Color", materialProperties.color);
+    
+                            ImGui::Text("Texture");
+                            DrawTextureWidget("##Albedo", materialTextures.albedo);
+    
+                            ImGui::EndChild();
+                            ImGui::TreePop();
+                        }
+                        if (ImGui::TreeNode("Metallic"))
+                        {
+                            ImGui::BeginChild("##Metallic Child", {0, 0},
+                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                            ImGui::Text("Metallic");
+                            ImGui::SliderFloat("##Metallic Slider", &materialProperties.metallic, 0.0f, 1.0f);
+                            ImGui::Text("Texture");
+                            DrawTextureWidget("##Metallic", materialTextures.metallic);
+                            ImGui::EndChild();
+                            ImGui::TreePop();
+                        }
+                        if (ImGui::TreeNode("Roughness"))
+                        {
+                            ImGui::BeginChild("##Roughness Child", {0, 0},
+                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                            ImGui::Text("Roughness");
+                            ImGui::SliderFloat("##Roughness Slider", &materialProperties.roughness, 0.0f, 1.0f);
+                            ImGui::Text("Texture");
+                            DrawTextureWidget("##Roughness", materialTextures.roughness);
+                            ImGui::EndChild();
+                            ImGui::TreePop();
+                        }
+                        if (ImGui::TreeNode("Emission"))
+                        {
+                            ImGui::BeginChild("##Emission Child", {0, 0},
+                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                            // FIXME: Emissive color variable is local and do not affect the materialProperties.emissive!!
+                            glm::vec4& emissiveColor = reinterpret_cast<glm::vec4&>(materialProperties.emissive);
+                            emissiveColor.a = 1.0f;
+                            DrawCustomColorEdit4("Color", emissiveColor);
+                            ImGui::Text("Texture");
+                            DrawTextureWidget("##Emissive", materialTextures.emissive);
+                            ImGui::EndChild();
+                            ImGui::TreePop();
+                        }
+                        if (ImGui::TreeNode("Normal Map"))
+                        {
+                            ImGui::BeginChild("##Normal Child", {0, 0},
+                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                            ImGui::Text("Texture");
+                            DrawTextureWidget("##Normal", materialTextures.normal);
+                            ImGui::EndChild();
+                            ImGui::TreePop();
+                        }
+                        if (ImGui::TreeNode("Ambient Occlusion"))
+                        {
+                            ImGui::BeginChild("##AO Child", {0, 0}, ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                            ImGui::Text("AO");
+                            ImGui::SliderFloat("##AO Slider", &materialProperties.ao, 0.0f, 1.0f);
+                            ImGui::Text("Texture");
+                            DrawTextureWidget("##AO", materialTextures.ao);
+                            ImGui::EndChild();
+                            ImGui::TreePop();
+                        }
+    
+                        if (!isCollapsingHeaderOpen)
+                        {
+                            entity.RemoveComponent<MaterialComponent>();
+                        }
                     }
                 }
             }
@@ -2927,7 +2932,7 @@ namespace Coffee
                 {
                     if(!entity.HasComponent<MaterialComponent>())
                     {
-                        entity.AddComponent<MaterialComponent>(Material::Create("Default Material"));
+                        entity.AddComponent<MaterialComponent>(PBRMaterial::Create("Default Material"));
                     }
                     ImGui::CloseCurrentPopup();
                 }
@@ -3240,7 +3245,7 @@ namespace Coffee
                 {
                     Entity e = m_Context->CreateEntity("Primitive");
                     e.AddComponent<MeshComponent>();
-                    e.AddComponent<MaterialComponent>(Material::Create("Default Material"));
+                    e.AddComponent<MaterialComponent>(PBRMaterial::Create("Default Material"));
                     SetSelectedEntity(e);
                     ImGui::CloseCurrentPopup();
                 }

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -3,6 +3,7 @@
 #include "CoffeeEngine/Core/Base.h"
 #include "CoffeeEngine/Core/FileDialog.h"
 #include "CoffeeEngine/IO/Resource.h"
+#include "CoffeeEngine/IO/ResourceRegistry.h"
 #include "CoffeeEngine/Renderer/Camera.h"
 #include "CoffeeEngine/Renderer/Material.h"
 #include "CoffeeEngine/Renderer/Model.h"
@@ -27,6 +28,8 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <glm/fwd.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <imgui.h>
@@ -863,14 +866,266 @@ namespace Coffee
                 }
             };
 
+            static bool ShowShaderQuickLoad = false;
+
             auto& materialComponent = entity.GetComponent<MaterialComponent>();
             bool isCollapsingHeaderOpen = true;
-            if (!materialComponent.material)
+            if (ImGui::CollapsingHeader("Material", &isCollapsingHeaderOpen, ImGuiTreeNodeFlags_DefaultOpen))
             {
-                if (ImGui::CollapsingHeader("Material (Missing)", &isCollapsingHeaderOpen,
-                                            ImGuiTreeNodeFlags_DefaultOpen))
+                // Check if the material is valid
+                if (!materialComponent.material)
                 {
-                    ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "Material is missing or invalid!");
+                    // If the material is not valid render a button to choose a new one
+
+                    static bool MaterialSelectorOpen = false;
+
+                    ImGui::Text("Material");
+                    ImGui::SameLine();
+                    if (ImGui::Button("<Empty>", {64, 32}))
+                    {
+                        MaterialSelectorOpen = true;
+                    }
+
+                    if (MaterialSelectorOpen)
+                    {
+                        ImGui::OpenPopup("MaterialPopup");
+                        MaterialSelectorOpen = false;
+                    }
+
+                    if (ImGui::BeginPopup("MaterialPopup"))
+                    {
+                        if (ImGui::MenuItem(ICON_LC_BOX "PBRMaterial"))
+                        {
+                            materialComponent.material = PBRMaterial::Create();
+                        }
+                        if (ImGui::MenuItem(ICON_LC_SQUARE_CHART_GANTT "ShaderMaterial"))
+                        {
+                            materialComponent.material = ShaderMaterial::Create();
+                        }
+                        ImGui::Separator();
+                        if (ImGui::MenuItem(ICON_LC_FOLDER "Quick Load...", NULL, false, false))
+                        {
+                        }
+                        {
+                        }
+                        if (ImGui::MenuItem(ICON_LC_FOLDER "Load...", NULL, false, false))
+                        {
+                            /*std::string path = FileDialog::OpenFile({}).string();
+                            if (!path.empty())
+                            {
+                            }
+                            */
+                        }
+                        ImGui::EndPopup();
+                    }
+
+                    if (!isCollapsingHeaderOpen)
+                    {
+                        entity.RemoveComponent<MaterialComponent>();
+                    }
+                    return;
+                }
+
+                if (materialComponent.material->GetType() == ResourceType::PBRMaterial)
+                {
+                    PBRMaterial& pbrMaterial = *std::static_pointer_cast<PBRMaterial>(materialComponent.material);
+
+                    PBRMaterialTextures& materialTextures = pbrMaterial.GetTextures();
+                    PBRMaterialProperties& materialProperties = pbrMaterial.GetProperties();
+                    MaterialRenderSettings& materialRenderSettings = pbrMaterial.GetRenderSettings();
+
+                    if (ImGui::TreeNode("Render Settings"))
+                    {
+                        ImGui::BeginChild("##RenderSettings Child", {0, 0},
+                                            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+
+                        ImGui::Text("Transparency");
+                        ImGui::SameLine();
+                        ImGui::Combo("##Transparency", (int*)&materialRenderSettings.transparencyMode,
+                                        "Disabled\0Alpha\0AlphaCutoff\0");
+
+                        if (materialRenderSettings.transparencyMode == MaterialRenderSettings::TransparencyMode::AlphaCutoff)
+                        {
+                            ImGui::Text("Alpha Cutoff");
+                            ImGui::SameLine();
+                            ImGui::SliderFloat("##AlphaCutoff", &materialRenderSettings.alphaCutoff, 0.0f, 1.0f);
+                        }
+                        
+                        ImGui::Text("Cull Mode");
+                        ImGui::SameLine();
+                        ImGui::Combo("##CullMode", (int*)&materialRenderSettings.cullMode,
+                                        "Front\0Back\0None\0");
+
+                        ImGui::Text("Depth Test");
+                        ImGui::SameLine();
+                        ImGui::Checkbox("##DepthTest", &materialRenderSettings.depthTest);
+
+                        ImGui::Text("Wireframe");
+                        ImGui::SameLine();
+                        ImGui::Checkbox("##Wireframe", &materialRenderSettings.wireframe);
+
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+
+                    if (ImGui::TreeNode("Albedo"))
+                    {
+                        ImGui::BeginChild("##Albedo Child", {0, 0},
+                                            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+
+                        ImGui::Text("Color");
+                        DrawCustomColorEdit4("##Albedo Color", materialProperties.color);
+
+                        ImGui::Text("Texture");
+                        DrawTextureWidget("##Albedo", materialTextures.albedo);
+
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+                    if (ImGui::TreeNode("Metallic"))
+                    {
+                        ImGui::BeginChild("##Metallic Child", {0, 0},
+                                            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                        ImGui::Text("Metallic");
+                        ImGui::SliderFloat("##Metallic Slider", &materialProperties.metallic, 0.0f, 1.0f);
+                        ImGui::Text("Texture");
+                        DrawTextureWidget("##Metallic", materialTextures.metallic);
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+                    if (ImGui::TreeNode("Roughness"))
+                    {
+                        ImGui::BeginChild("##Roughness Child", {0, 0},
+                                            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                        ImGui::Text("Roughness");
+                        ImGui::SliderFloat("##Roughness Slider", &materialProperties.roughness, 0.0f, 1.0f);
+                        ImGui::Text("Texture");
+                        DrawTextureWidget("##Roughness", materialTextures.roughness);
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+                    if (ImGui::TreeNode("Emission"))
+                    {
+                        ImGui::BeginChild("##Emission Child", {0, 0},
+                                            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                        // FIXME: Emissive color variable is local and do not affect the materialProperties.emissive!!
+                        glm::vec4& emissiveColor = reinterpret_cast<glm::vec4&>(materialProperties.emissive);
+                        emissiveColor.a = 1.0f;
+                        DrawCustomColorEdit4("Color", emissiveColor);
+                        ImGui::Text("Texture");
+                        DrawTextureWidget("##Emissive", materialTextures.emissive);
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+                    if (ImGui::TreeNode("Normal Map"))
+                    {
+                        ImGui::BeginChild("##Normal Child", {0, 0},
+                                            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                        ImGui::Text("Texture");
+                        DrawTextureWidget("##Normal", materialTextures.normal);
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+                    if (ImGui::TreeNode("Ambient Occlusion"))
+                    {
+                        ImGui::BeginChild("##AO Child", {0, 0}, ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+                        ImGui::Text("AO");
+                        ImGui::SliderFloat("##AO Slider", &materialProperties.ao, 0.0f, 1.0f);
+                        ImGui::Text("Texture");
+                        DrawTextureWidget("##AO", materialTextures.ao);
+                        ImGui::EndChild();
+                        ImGui::TreePop();
+                    }
+
+                    if (!isCollapsingHeaderOpen)
+                    {
+                        entity.RemoveComponent<MaterialComponent>();
+                    }
+                }
+                else if (materialComponent.material->GetType() == ResourceType::ShaderMaterial)
+                {
+                    ShaderMaterial& shaderMaterial = *std::static_pointer_cast<ShaderMaterial>(materialComponent.material);
+                    ImGui::Text("Shader");
+                    ImGui::SameLine();
+                    std::string shaderName = shaderMaterial.GetShader() ? shaderMaterial.GetShader()->GetName() : "<Empty>";
+                    
+                    static bool LoadShaderPopupOpen = false;
+
+                    if (ImGui::Button(shaderName.c_str(), {64, 32}))
+                    {
+                        if (!shaderMaterial.GetShader())
+                        {
+                            LoadShaderPopupOpen = true;
+                        }
+                        else 
+                        {
+                            SDL_OpenURL(("file://" + std::filesystem::absolute(shaderMaterial.GetShader()->GetPath()).string()).c_str());
+                        }
+                    }
+                    if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+                    {
+                        LoadShaderPopupOpen = true;
+                    }
+
+                    if (LoadShaderPopupOpen)
+                    {
+                        ImGui::OpenPopup("LoadShaderPopup");
+                        LoadShaderPopupOpen = false;
+                    }
+
+                    if(ImGui::BeginPopup("LoadShaderPopup"))
+                    {
+                        if (ImGui::MenuItem(ICON_LC_SQUARE_CHART_GANTT "New Shader..."))
+                        {
+                            std::string path = FileDialog::SaveFile({}).string();
+                            if (!path.empty())
+                            {
+                                std::ofstream scriptFile(path);
+                                std::ifstream defaultShaderFile("assets/shaders/DefaultCustomShader.glsl");
+                                if (scriptFile.is_open() and defaultShaderFile.is_open())
+                                {
+                                    scriptFile << defaultShaderFile.rdbuf();
+                                    scriptFile.close();
+                                    defaultShaderFile.close();
+                                }
+                                Ref<Shader> shader = Shader::Create(path);
+                                shaderMaterial.SetShader(shader);
+                            }
+                        }
+                        ImGui::Separator();
+                        if (ImGui::MenuItem(ICON_LC_FOLDER "Quick Load..."))
+                        {
+                            ShowShaderQuickLoad = true;
+                        }
+                        if (ImGui::MenuItem(ICON_LC_FOLDER "Load..."))
+                        {
+                            std::string path = FileDialog::OpenFile({}).string();
+                            if (!path.empty())
+                            {
+                                Ref<Shader> shader = Shader::Create(path);
+                                shaderMaterial.SetShader(shader);
+                            }
+                        }
+                        ImGui::EndPopup();
+                    }
+
+                    if (ImGui::BeginDragDropTarget())
+                    {
+                        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("RESOURCE"))
+                        {
+                            const Ref<Resource>& resource = *(Ref<Resource>*)payload->Data;
+                            if (resource->GetType() == ResourceType::Shader)
+                            {
+                                const Ref<Shader>& t = std::static_pointer_cast<Shader>(resource);
+                                shaderMaterial.SetShader(t);
+                            }
+                        }
+                        ImGui::EndDragDropTarget();
+                    }
+                    if (ImGui::Button("Recompile"))
+                    {
+                        if (shaderMaterial.GetShader()) shaderMaterial.GetShader()->Recompile();
+                    }
 
                     if (!isCollapsingHeaderOpen)
                     {
@@ -878,127 +1133,35 @@ namespace Coffee
                     }
                 }
             }
-            else
-            {
-                if (ImGui::CollapsingHeader("Material", &isCollapsingHeaderOpen, ImGuiTreeNodeFlags_DefaultOpen))
-                {
-                    if (materialComponent.material->GetType() == ResourceType::PBRMaterial)
-                    {
-                        PBRMaterial& pbrMaterial = *std::static_pointer_cast<PBRMaterial>(materialComponent.material);
 
-                        PBRMaterialTextures& materialTextures = pbrMaterial.GetTextures();
-                        PBRMaterialProperties& materialProperties = pbrMaterial.GetProperties();
-                        MaterialRenderSettings& materialRenderSettings = pbrMaterial.GetRenderSettings();
-    
-                        if (ImGui::TreeNode("Render Settings"))
+            if (ShowShaderQuickLoad)
+            {
+                ImGui::OpenPopup("ShaderQuickLoad");
+                ShowShaderQuickLoad = false;
+            }
+            if (ImGui::BeginPopupModal("ShaderQuickLoad"))
+            {
+                ImGui::Text("Quick Load");
+                ImGui::Separator();
+                auto& registry = ResourceRegistry::GetResourceRegistry();
+                for (auto& shader : registry)
+                {
+                    if (shader.second->GetType() == ResourceType::Shader)
+                    {
+                        const Ref<Shader>& t = std::static_pointer_cast<Shader>(shader.second);
+                        if (ImGui::Selectable(t->GetName().c_str()))
                         {
-                            ImGui::BeginChild("##RenderSettings Child", {0, 0},
-                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-    
-                            ImGui::Text("Transparency");
-                            ImGui::SameLine();
-                            ImGui::Combo("##Transparency", (int*)&materialRenderSettings.transparencyMode,
-                                         "Disabled\0Alpha\0AlphaCutoff\0");
-    
-                            if (materialRenderSettings.transparencyMode == MaterialRenderSettings::TransparencyMode::AlphaCutoff)
-                            {
-                                ImGui::Text("Alpha Cutoff");
-                                ImGui::SameLine();
-                                ImGui::SliderFloat("##AlphaCutoff", &materialRenderSettings.alphaCutoff, 0.0f, 1.0f);
-                            }
-                            
-                            ImGui::Text("Cull Mode");
-                            ImGui::SameLine();
-                            ImGui::Combo("##CullMode", (int*)&materialRenderSettings.cullMode,
-                                         "Front\0Back\0None\0");
-    
-                            ImGui::Text("Depth Test");
-                            ImGui::SameLine();
-                            ImGui::Checkbox("##DepthTest", &materialRenderSettings.depthTest);
-    
-                            ImGui::Text("Wireframe");
-                            ImGui::SameLine();
-                            ImGui::Checkbox("##Wireframe", &materialRenderSettings.wireframe);
-    
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-    
-                        if (ImGui::TreeNode("Albedo"))
-                        {
-                            ImGui::BeginChild("##Albedo Child", {0, 0},
-                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-    
-                            ImGui::Text("Color");
-                            DrawCustomColorEdit4("##Albedo Color", materialProperties.color);
-    
-                            ImGui::Text("Texture");
-                            DrawTextureWidget("##Albedo", materialTextures.albedo);
-    
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-                        if (ImGui::TreeNode("Metallic"))
-                        {
-                            ImGui::BeginChild("##Metallic Child", {0, 0},
-                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                            ImGui::Text("Metallic");
-                            ImGui::SliderFloat("##Metallic Slider", &materialProperties.metallic, 0.0f, 1.0f);
-                            ImGui::Text("Texture");
-                            DrawTextureWidget("##Metallic", materialTextures.metallic);
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-                        if (ImGui::TreeNode("Roughness"))
-                        {
-                            ImGui::BeginChild("##Roughness Child", {0, 0},
-                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                            ImGui::Text("Roughness");
-                            ImGui::SliderFloat("##Roughness Slider", &materialProperties.roughness, 0.0f, 1.0f);
-                            ImGui::Text("Texture");
-                            DrawTextureWidget("##Roughness", materialTextures.roughness);
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-                        if (ImGui::TreeNode("Emission"))
-                        {
-                            ImGui::BeginChild("##Emission Child", {0, 0},
-                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                            // FIXME: Emissive color variable is local and do not affect the materialProperties.emissive!!
-                            glm::vec4& emissiveColor = reinterpret_cast<glm::vec4&>(materialProperties.emissive);
-                            emissiveColor.a = 1.0f;
-                            DrawCustomColorEdit4("Color", emissiveColor);
-                            ImGui::Text("Texture");
-                            DrawTextureWidget("##Emissive", materialTextures.emissive);
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-                        if (ImGui::TreeNode("Normal Map"))
-                        {
-                            ImGui::BeginChild("##Normal Child", {0, 0},
-                                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                            ImGui::Text("Texture");
-                            DrawTextureWidget("##Normal", materialTextures.normal);
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-                        if (ImGui::TreeNode("Ambient Occlusion"))
-                        {
-                            ImGui::BeginChild("##AO Child", {0, 0}, ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
-                            ImGui::Text("AO");
-                            ImGui::SliderFloat("##AO Slider", &materialProperties.ao, 0.0f, 1.0f);
-                            ImGui::Text("Texture");
-                            DrawTextureWidget("##AO", materialTextures.ao);
-                            ImGui::EndChild();
-                            ImGui::TreePop();
-                        }
-    
-                        if (!isCollapsingHeaderOpen)
-                        {
-                            entity.RemoveComponent<MaterialComponent>();
+                            auto shaderMaterial = std::static_pointer_cast<ShaderMaterial>(materialComponent.material);
+                            shaderMaterial->SetShader(t);
+                            ImGui::CloseCurrentPopup();
                         }
                     }
                 }
+                if(ImGui::Button("Close"))
+                {
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::EndPopup();
             }
         }
 
@@ -2930,9 +3093,9 @@ namespace Coffee
                 }
                 else if (items[item_current] == "Material Component")
                 {
-                    if(!entity.HasComponent<MaterialComponent>())
+                    if (!entity.HasComponent<MaterialComponent>())
                     {
-                        entity.AddComponent<MaterialComponent>(PBRMaterial::Create("Default Material"));
+                        entity.AddComponent<MaterialComponent>();
                     }
                     ImGui::CloseCurrentPopup();
                 }
@@ -3114,6 +3277,41 @@ namespace Coffee
 
             ImGui::EndPopup();
         }
+
+/*         if (ShowMaterialOptions)
+        {
+            ImGui::OpenPopup("Select Material Type");
+            ShowMaterialOptions = false;
+        }
+
+        if (ImGui::BeginPopupModal("Select Material Type"))
+        {
+            ImGui::Text("Choose the type of material to create:");
+            ImGui::Separator();
+    
+            if (ImGui::Button("PBRMaterial", ImVec2(120, 0)))
+            {
+                entity.AddComponent<MaterialComponent>(PBRMaterial::Create("Default PBR Material"));
+                ImGui::CloseCurrentPopup();
+            }
+    
+            ImGui::SameLine();
+    
+            if (ImGui::Button("ShaderMaterial", ImVec2(120, 0)))
+            {
+                entity.AddComponent<MaterialComponent>(ShaderMaterial::Create("Default Shader Material"));
+                ImGui::CloseCurrentPopup();
+            }
+    
+            ImGui::Separator();
+    
+            if (ImGui::Button("Cancel", ImVec2(240, 0)))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+    
+            ImGui::EndPopup();
+        } */
 
         // Add Lua script component options
         if (m_ShowLuaScriptOptions)

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -858,7 +858,7 @@ namespace Coffee
                 if (ImGui::BeginPopup("AlbedoColorPopup"))
                 {
                     ImGui::ColorPicker4((label + "Picker").c_str(), glm::value_ptr(color),
-                                        ImGuiColorEditFlags_NoInputs);
+                                        ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreview);
                     ImGui::EndPopup();
                 }
             };
@@ -895,6 +895,13 @@ namespace Coffee
                         ImGui::SameLine();
                         ImGui::Combo("##Transparency", (int*)&materialRenderSettings.transparencyMode,
                                      "Disabled\0Alpha\0AlphaCutoff\0");
+
+                        if (materialRenderSettings.transparencyMode == MaterialRenderSettings::TransparencyMode::AlphaCutoff)
+                        {
+                            ImGui::Text("Alpha Cutoff");
+                            ImGui::SameLine();
+                            ImGui::SliderFloat("##AlphaCutoff", &materialRenderSettings.alphaCutoff, 0.0f, 1.0f);
+                        }
                         
                         ImGui::Text("Cull Mode");
                         ImGui::SameLine();

--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -897,10 +897,12 @@ namespace Coffee
                         if (ImGui::MenuItem(ICON_LC_BOX "PBRMaterial"))
                         {
                             materialComponent.material = PBRMaterial::Create();
+                            materialComponent.material->SetEmbedded(true);
                         }
                         if (ImGui::MenuItem(ICON_LC_SQUARE_CHART_GANTT "ShaderMaterial"))
                         {
                             materialComponent.material = ShaderMaterial::Create();
+                            materialComponent.material->SetEmbedded(true);
                         }
                         ImGui::Separator();
                         if (ImGui::MenuItem(ICON_LC_FOLDER "Quick Load...", NULL, false, false))

--- a/CoffeeEditor/assets/shaders/DefaultCustomShader.glsl
+++ b/CoffeeEditor/assets/shaders/DefaultCustomShader.glsl
@@ -1,7 +1,3 @@
-// DefaultCustomShader.inl
-#pragma once
-
-inline const char* defaultCustomShaderSource = R"(
 #[vertex]
 
 #version 450 core
@@ -57,4 +53,3 @@ void main()
     FragColor = vec4(1.0, 1.0, 1.0, 1.0);
     EntityID = vec4(entityID, 1.0f);
 }
-)";

--- a/CoffeeEditor/assets/shaders/DefaultCustomShader.glsl
+++ b/CoffeeEditor/assets/shaders/DefaultCustomShader.glsl
@@ -1,0 +1,60 @@
+// DefaultCustomShader.inl
+#pragma once
+
+inline const char* defaultCustomShaderSource = R"(
+#[vertex]
+
+#version 450 core
+layout (location = 0) in vec3 aPosition;
+layout (location = 1) in vec2 aTexCoord;
+
+layout (std140, binding = 0) uniform camera
+{
+    mat4 projection;
+    mat4 view;
+    vec3 cameraPos;
+};
+
+struct VertexData
+{
+    vec2 TexCoords;
+    vec3 WorldPos;
+    vec3 camPos;
+};
+
+layout (location = 2) out VertexData Output;
+
+uniform mat4 model;
+
+void main()
+{
+    Output.TexCoords = aTexCoord;
+    Output.WorldPos = vec3(model * vec4(aPosition, 1.0));
+    Output.camPos = cameraPos;
+
+    gl_Position = projection * view * vec4(Output.WorldPos, 1.0);
+}
+
+#[fragment]
+
+#version 450 core
+layout(location = 0) out vec4 FragColor;
+layout(location = 1) out vec4 EntityID;
+
+uniform vec3 entityID;
+
+struct VertexData
+{
+    vec2 TexCoords;
+    vec3 WorldPos;
+    vec3 camPos;
+};
+
+layout (location = 2) in VertexData VertexInput;
+
+void main()
+{
+    FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+    EntityID = vec4(entityID, 1.0f);
+}
+)";

--- a/CoffeeEditor/src/EditorLayer.cpp
+++ b/CoffeeEditor/src/EditorLayer.cpp
@@ -15,6 +15,7 @@
 #include "CoffeeEngine/Project/Project.h"
 #include "CoffeeEngine/Renderer/EditorCamera.h"
 #include "CoffeeEngine/Renderer/Framebuffer.h"
+#include "CoffeeEngine/Renderer/Material.h"
 #include "CoffeeEngine/Renderer/RenderTarget.h"
 #include "CoffeeEngine/Renderer/Renderer.h"
 #include "CoffeeEngine/Renderer/Renderer2D.h"
@@ -702,12 +703,14 @@ namespace Coffee {
         Renderer2D::DrawLine({0.0f, -1000.0f, 0.0f}, {0.0f, 1000.0f, 0.0f}, {0.502f, 0.800f, 0.051f, 1.0f}, 2);
         Renderer2D::DrawLine({0.0f, 0.0f, -1000.0f}, {0.0f, 0.0f, 1000.0f}, {0.153f, 0.525f, 0.918f, 1.0f}, 2);
 
-        static Ref<Mesh> gridPlaneDown = PrimitiveMesh::CreatePlane({1000.0f, 1000.0f});
-        static Ref<Mesh> gridPlaneUp = PrimitiveMesh::CreatePlane({1000.0f, -1000.0f}); // FIXME this is a hack to avoid the grid not beeing rendered due to backface culling
+        static Ref<Mesh> gridPlane = PrimitiveMesh::CreatePlane({1000.0f, 1000.0f});
         static Ref<Shader> gridShader = Shader::Create("assets/shaders/SimpleGridShader.glsl");
+        static Ref<Material> gridShaderMaterial = ShaderMaterial::Create("GridShaderMaterial", gridShader);
+        MaterialRenderSettings& gridMaterialRenderSettings = gridShaderMaterial->GetRenderSettings();
+        gridMaterialRenderSettings.cullMode = MaterialRenderSettings::CullMode::None;
+        gridMaterialRenderSettings.transparencyMode = MaterialRenderSettings::TransparencyMode::Alpha;
 
-        Renderer3D::Submit(gridShader, gridPlaneUp->GetVertexArray());
-        Renderer3D::Submit(gridShader, gridPlaneDown->GetVertexArray());
+        Renderer3D::Submit(RenderCommand{.mesh = gridPlane, .material = gridShaderMaterial});
     }
 
     void EditorLayer::ResizeViewport(float width, float height)

--- a/CoffeeEngine/src/CoffeeEngine/Embedded/StandardShader.inl
+++ b/CoffeeEngine/src/CoffeeEngine/Embedded/StandardShader.inl
@@ -138,6 +138,12 @@ struct Material
     float ao;
     vec3 emissive;
 
+    int transparencyMode;
+    // 0 = opaque
+    // 1 = alpha
+    // 2 = alpha cutoff
+    float alphaCutoff;
+
     int hasAlbedo;
     int hasNormal;
     int hasMetallic;
@@ -276,6 +282,17 @@ void main()
 {
     vec3 albedo = material.hasAlbedo * (texture(material.albedoMap, VertexInput.TexCoords).rgb * material.color.rgb) + (1 - material.hasAlbedo) * material.color.rgb;
 
+    float alpha = 1.0;
+    if (material.transparencyMode == 1) {
+        alpha = material.hasAlbedo * (texture(material.albedoMap, VertexInput.TexCoords).a) + (1 - material.hasAlbedo) * material.color.a;
+    }
+    else if (material.transparencyMode == 2) {
+        alpha = material.hasAlbedo * (texture(material.albedoMap, VertexInput.TexCoords).a) + (1 - material.hasAlbedo) * material.color.a;
+        if (alpha < material.alphaCutoff) {
+            discard;
+        }
+    }
+
     // Revise this type of conditional assignment (the commented one) because i think can lead to some undefined behavior in the shader!!!!!
     vec3 normal/*  = material.hasNormal * (VertexInput.TBN * (texture(material.normalMap, VertexInput.TexCoords).rgb * 2.0 - 1.0)) + (1 - material.hasNormal) * VertexInput.Normal */;
     if (material.hasNormal == 1) {
@@ -364,7 +381,7 @@ void main()
     vec3 ambient = (kD * diffuse + specular) * ao;
     vec3 color = ambient + Lo + emissive;
 
-    FragColor = vec4(vec3(color), 1.0);
+    FragColor = vec4(color, alpha);
     EntityID = vec4(entityID, 1.0f); //set the alpha to 0
 
     //REMOVE: This is for the first release of the engine it should be handled differently

--- a/CoffeeEngine/src/CoffeeEngine/IO/ImportData/ImportDataUtils.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ImportData/ImportDataUtils.cpp
@@ -108,9 +108,9 @@ namespace Coffee {
             {
                 return CreateScope<ModelImportData>();
             }
-            case ResourceType::Material:
+            case ResourceType::PBRMaterial:
             {
-                return CreateScope<MaterialImportData>();
+                return CreateScope<PBRMaterialImportData>();
             }
             case ResourceType::Shader:
             {

--- a/CoffeeEngine/src/CoffeeEngine/IO/ImportData/MaterialImportData.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ImportData/MaterialImportData.h
@@ -6,15 +6,15 @@
 
 namespace Coffee
 {
-    struct MaterialTextures;
+    struct PBRMaterialTextures;
 
-    struct MaterialImportData : public ImportData
+    struct PBRMaterialImportData : public ImportData
     {
 
         std::string name;
-        MaterialTextures* materialTextures;
+        PBRMaterialTextures* materialTextures;
 
-        MaterialImportData() : ImportData(ResourceType::Material) {}
+        PBRMaterialImportData() : ImportData(ResourceType::PBRMaterial) {}
 
         template <typename Archive> void serialize(Archive& archive, std::uint32_t const version)
         {
@@ -23,5 +23,5 @@ namespace Coffee
     };
 
 } // namespace Coffee
-CEREAL_REGISTER_TYPE(Coffee::MaterialImportData);
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Coffee::ImportData, Coffee::MaterialImportData);
+CEREAL_REGISTER_TYPE(Coffee::PBRMaterialImportData);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(Coffee::ImportData, Coffee::PBRMaterialImportData);

--- a/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
@@ -119,7 +119,7 @@ namespace Coffee {
         template <class Archive> void save(Archive& archive, std::uint32_t const version) const
         {
             int typeInt = static_cast<int>(m_Type);
-            archive(m_Name, m_FilePath, typeInt, m_UUID);
+            archive(m_Name, m_FilePath, typeInt, m_UUID, m_isEmbedded);
         }
 
         /**
@@ -130,7 +130,7 @@ namespace Coffee {
         template <class Archive> void load(Archive& archive, std::uint32_t const version)
         {
             int typeInt;
-            archive(m_Name, m_FilePath, typeInt, m_UUID);
+            archive(m_Name, m_FilePath, typeInt, m_UUID, m_isEmbedded);
             m_Type = static_cast<ResourceType>(typeInt);
         }
 

--- a/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
@@ -96,6 +96,18 @@ namespace Coffee {
          */
         UUID GetUUID() const { return m_UUID; }
 
+        /**
+         * @brief Sets the embedded status of the resource.
+         * @param isEmbedded The embedded status to set.
+         */
+        void SetEmbedded(bool isEmbedded) { m_isEmbedded = isEmbedded; }
+
+        /**
+         * @brief Checks if the resource is embedded.
+         * @return True if the resource is embedded, false otherwise.
+         */
+        bool IsEmbedded() const { return m_isEmbedded; }
+
     private:
         friend class cereal::access;
 
@@ -127,6 +139,7 @@ namespace Coffee {
         std::filesystem::path m_FilePath; ///< The file path of the resource.
         ResourceType m_Type; ///< The type of the resource.
         UUID m_UUID; ///< The UUID of the resource.
+        bool m_isEmbedded = false; ///< Flag indicating if the resource is embedded. // TODO: Revise if this is the right place for this
     };
 
 }

--- a/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/Resource.h
@@ -30,6 +30,8 @@ namespace Coffee {
         Mesh,   ///< Mesh resource type
         Shader,   ///< Shader resource type
         Material, ///< Material resource type
+        PBRMaterial, ///< PBRMaterial resource type
+        ShaderMaterial, ///< ShaderMaterial resource type
         AnimationSystem, ///< AnimationSystem resource type
         Skeleton, ///< Skeleton resource type
         Animation, ///< Animation resource type

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceImporter.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceImporter.h
@@ -28,7 +28,7 @@ namespace Coffee {
     struct Vertex;
 
     class Material;
-    struct MaterialTextures;
+    struct PBRMaterialTextures;
     class Texture;
     class Texture2D;
 

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceLoader.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceLoader.cpp
@@ -84,6 +84,11 @@ namespace Coffee {
                     Load<PBRMaterial>(*importData);
                     break;
                 }
+                case ResourceType::ShaderMaterial:
+                {
+                    Load<ShaderMaterial>(*importData);
+                    break;
+                }
                 default:
                 {
                     COFFEE_CORE_ERROR("ResourceLoader::LoadResources: Unsupported resource type {0}", ResourceTypeToString(importData->type));
@@ -233,6 +238,11 @@ namespace Coffee {
             case ResourceType::PBRMaterial:
             {
                 Load<PBRMaterial>(*importData);
+                break;
+            }
+            case ResourceType::ShaderMaterial:
+            {
+                Load<ShaderMaterial>(*importData);
                 break;
             }
             default:

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceLoader.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceLoader.cpp
@@ -79,9 +79,9 @@ namespace Coffee {
                     Load<Shader>(*importData);
                     break;
                 }
-                case ResourceType::Material:
+                case ResourceType::PBRMaterial:
                 {
-                    Load<Material>(*importData);
+                    Load<PBRMaterial>(*importData);
                     break;
                 }
                 default:
@@ -230,9 +230,9 @@ namespace Coffee {
                 Load<Shader>(*importData);
                 break;
             }
-            case ResourceType::Material:
+            case ResourceType::PBRMaterial:
             {
-                Load<Material>(*importData);
+                Load<PBRMaterial>(*importData);
                 break;
             }
             default:

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
@@ -12,6 +12,7 @@ namespace Coffee {
     class Model;
     class Mesh;
     class Material;
+    class PBRMaterial;
 
     inline ResourceType GetResourceTypeFromExtension(const std::filesystem::path& path)
     {
@@ -57,6 +58,8 @@ namespace Coffee {
             return "Shader";
         case ResourceType::Material:
             return "Material";
+        case ResourceType::PBRMaterial:
+            return "PBRMaterial";
         case ResourceType::Prefab:
             return "Prefab";
         default:
@@ -80,6 +83,8 @@ namespace Coffee {
             return ".shader";
         case ResourceType::Material:
             return ".material";
+        case ResourceType::PBRMaterial:
+            return ".pbrmaterial";
         default:
             return ".unknown";
         }
@@ -133,6 +138,10 @@ namespace Coffee {
         else if constexpr (std::is_same<T, Material>::value)
         {
             return ResourceType::Material;
+        }
+        else if constexpr (std::is_same<T, PBRMaterial>::value)
+        {
+            return ResourceType::PBRMaterial;
         }
         else if constexpr (std::is_same<T, Shader>::value)
         {

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
@@ -13,6 +13,7 @@ namespace Coffee {
     class Mesh;
     class Material;
     class PBRMaterial;
+    class ShaderMaterial;
 
     inline ResourceType GetResourceTypeFromExtension(const std::filesystem::path& path)
     {
@@ -60,6 +61,8 @@ namespace Coffee {
             return "Material";
         case ResourceType::PBRMaterial:
             return "PBRMaterial";
+        case ResourceType::ShaderMaterial:
+            return "ShaderMaterial";
         case ResourceType::Prefab:
             return "Prefab";
         default:
@@ -85,6 +88,8 @@ namespace Coffee {
             return ".material";
         case ResourceType::PBRMaterial:
             return ".pbrmaterial";
+        case ResourceType::ShaderMaterial:
+            return ".shadermaterial";
         default:
             return ".unknown";
         }
@@ -142,6 +147,10 @@ namespace Coffee {
         else if constexpr (std::is_same<T, PBRMaterial>::value)
         {
             return ResourceType::PBRMaterial;
+        }
+        else if constexpr (std::is_same<T, ShaderMaterial>::value)
+        {
+            return ResourceType::ShaderMaterial;
         }
         else if constexpr (std::is_same<T, Shader>::value)
         {

--- a/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
+++ b/CoffeeEngine/src/CoffeeEngine/IO/ResourceUtils.h
@@ -140,10 +140,6 @@ namespace Coffee {
         {
             return ResourceType::Mesh;
         }
-        else if constexpr (std::is_same<T, Material>::value)
-        {
-            return ResourceType::Material;
-        }
         else if constexpr (std::is_same<T, PBRMaterial>::value)
         {
             return ResourceType::PBRMaterial;
@@ -151,6 +147,10 @@ namespace Coffee {
         else if constexpr (std::is_same<T, ShaderMaterial>::value)
         {
             return ResourceType::ShaderMaterial;
+        }
+        else if constexpr (std::is_same<T, Material>::value)
+        {
+            return ResourceType::Material;
         }
         else if constexpr (std::is_same<T, Shader>::value)
         {

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -34,7 +34,10 @@ namespace Coffee {
     {
         ZoneScoped;
 
-        m_Shader->Bind();
+        if (m_Shader)
+        {
+            m_Shader->Bind();
+        }
     }
 
     Ref<ShaderMaterial> ShaderMaterial::Create(const std::string& name, Ref<Shader> shader)

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -1,5 +1,6 @@
 #include "Material.h"
 #include "CoffeeEngine/Core/Base.h"
+#include "CoffeeEngine/IO/ImportData/ImportData.h"
 #include "CoffeeEngine/IO/ImportData/MaterialImportData.h"
 #include "CoffeeEngine/IO/Resource.h"
 #include "CoffeeEngine/IO/ResourceLoader.h"
@@ -9,6 +10,25 @@
 #include <tracy/Tracy.hpp>
 
 namespace Coffee {
+
+    ShaderMaterial::ShaderMaterial(ImportData& importData)
+        : Material(ResourceType::ShaderMaterial)
+    {
+        ZoneScoped;
+
+/*         ShaderMaterialImportData& shaderMaterialImportData = dynamic_cast<ShaderMaterialImportData&>(importData);
+
+        m_Name = shaderMaterialImportData.name;
+        m_UUID = shaderMaterialImportData.uuid;
+        m_FilePath = shaderMaterialImportData.cachedPath;
+
+        m_Shader = Shader::Create(shaderMaterialImportData.shaderPath); */
+
+        m_UUID = importData.uuid;
+        m_Name = importData.originalPath.stem().string();
+        m_Shader = Shader::Create(importData.originalPath);
+        m_FilePath = importData.cachedPath;
+    }
 
     void ShaderMaterial::Use()
     {

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -128,7 +128,6 @@ namespace Coffee {
 
         m_Name = materialImportData.name;
         m_UUID = materialImportData.uuid;
-        m_FilePath = materialImportData.cachedPath;
     }
 
     void PBRMaterial::Use()

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -10,6 +10,18 @@
 
 namespace Coffee {
 
+    void ShaderMaterial::Use()
+    {
+        ZoneScoped;
+
+        m_Shader->Bind();
+    }
+
+    Ref<ShaderMaterial> ShaderMaterial::Create(const std::string& name, Ref<Shader> shader)
+    {
+        return CreateRef<ShaderMaterial>(name, shader);
+    }
+
     Ref<Texture2D> PBRMaterial::s_MissingTexture;
     Ref<Shader> PBRMaterial::s_StandardShader;
 

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -138,6 +138,9 @@ namespace Coffee {
         m_Shader->setInt("material.hasRoughness", m_MaterialTextureFlags.hasRoughness);
         m_Shader->setInt("material.hasAO", m_MaterialTextureFlags.hasAO);
         m_Shader->setInt("material.hasEmissive", m_MaterialTextureFlags.hasEmissive);
+
+        m_Shader->setInt("material.transparencyMode", m_MaterialRenderSettings.transparencyMode);
+        m_Shader->setFloat("material.alphaCutoff", m_MaterialRenderSettings.alphaCutoff);
     }
 
     Ref<Material> Material::Create(const std::string& name, MaterialTextures* materialTextures)

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -3,50 +3,44 @@
 #include "CoffeeEngine/IO/ImportData/MaterialImportData.h"
 #include "CoffeeEngine/IO/Resource.h"
 #include "CoffeeEngine/IO/ResourceLoader.h"
-#include "CoffeeEngine/IO/ResourceRegistry.h"
 #include "CoffeeEngine/Renderer/Texture.h"
 #include "CoffeeEngine/Embedded/StandardShader.inl"
-#include <cstdint>
 #include <glm/fwd.hpp>
 #include <tracy/Tracy.hpp>
 
 namespace Coffee {
 
-    Ref<Texture2D> Material::s_MissingTexture;
-    Ref<Shader> Material::s_StandardShader;
+    Ref<Texture2D> PBRMaterial::s_MissingTexture;
+    Ref<Shader> PBRMaterial::s_StandardShader;
 
-     Material::Material() : Resource(ResourceType::Material)
+     PBRMaterial::PBRMaterial() : Material(ResourceType::PBRMaterial)
     {
         s_StandardShader  = s_StandardShader ? s_StandardShader : CreateRef<Shader>("StandardShader", std::string(standardShaderSource));
 
         m_Shader = s_StandardShader;
     }
 
-    Material::Material(const std::string& name)
-        : Resource(ResourceType::Material)
+    PBRMaterial::PBRMaterial(const std::string& name)
+        : Material(name, ResourceType::PBRMaterial)
     {
         ZoneScoped;
-
-        m_Name = name;
 
         s_MissingTexture = Texture2D::Load("assets/textures/UVMap-Grid.jpg");
         s_StandardShader  = s_StandardShader ? s_StandardShader : CreateRef<Shader>("StandardShader", std::string(standardShaderSource));
 
-        m_MaterialTextures.albedo = s_MissingTexture;
-        m_MaterialTextureFlags.hasAlbedo = true;
+        m_Textures.albedo = s_MissingTexture;
+        m_TextureFlags.hasAlbedo = true;
 
         m_Shader = s_StandardShader;
 
         m_Shader->Bind();
-        m_MaterialTextures.albedo->Bind(0);
+        m_Textures.albedo->Bind(0);
         m_Shader->setInt("material.albedoMap", 0);
         m_Shader->Unbind();
     }
 
-    Material::Material(const std::string& name, Ref<Shader> shader) : m_Shader(shader), Resource(ResourceType::Material) {}
-
-    Material::Material(const std::string& name, MaterialTextures& materialTextures)
-        : Resource(ResourceType::Material)
+    PBRMaterial::PBRMaterial(const std::string& name, PBRMaterialTextures& materialTextures)
+        : Material(ResourceType::PBRMaterial)
     {
         ZoneScoped;
 
@@ -54,22 +48,22 @@ namespace Coffee {
         
         m_Name = name;
 
-        m_MaterialTextures.albedo = materialTextures.albedo;
-        m_MaterialTextures.normal = materialTextures.normal;
-        m_MaterialTextures.metallic = materialTextures.metallic;
-        m_MaterialTextures.roughness = materialTextures.roughness;
-        m_MaterialTextures.ao = materialTextures.ao;
-        m_MaterialTextures.emissive = materialTextures.emissive;
+        m_Textures.albedo = materialTextures.albedo;
+        m_Textures.normal = materialTextures.normal;
+        m_Textures.metallic = materialTextures.metallic;
+        m_Textures.roughness = materialTextures.roughness;
+        m_Textures.ao = materialTextures.ao;
+        m_Textures.emissive = materialTextures.emissive;
 
-        m_MaterialTextureFlags.hasAlbedo = (m_MaterialTextures.albedo != nullptr);
-        m_MaterialTextureFlags.hasNormal = (m_MaterialTextures.normal != nullptr);
-        m_MaterialTextureFlags.hasMetallic = (m_MaterialTextures.metallic != nullptr);
-        m_MaterialTextureFlags.hasRoughness = (m_MaterialTextures.roughness != nullptr);
-        m_MaterialTextureFlags.hasAO = (m_MaterialTextures.ao != nullptr);
-        m_MaterialTextureFlags.hasEmissive = (m_MaterialTextures.emissive != nullptr);
+        m_TextureFlags.hasAlbedo = (m_Textures.albedo != nullptr);
+        m_TextureFlags.hasNormal = (m_Textures.normal != nullptr);
+        m_TextureFlags.hasMetallic = (m_Textures.metallic != nullptr);
+        m_TextureFlags.hasRoughness = (m_Textures.roughness != nullptr);
+        m_TextureFlags.hasAO = (m_Textures.ao != nullptr);
+        m_TextureFlags.hasEmissive = (m_Textures.emissive != nullptr);
 
-        if(m_MaterialTextureFlags.hasMetallic)m_MaterialProperties.metallic = 1.0f;
-        if(m_MaterialTextureFlags.hasEmissive)m_MaterialProperties.emissive = glm::vec3(1.0f);
+        if(m_TextureFlags.hasMetallic)m_Properties.metallic = 1.0f;
+        if(m_TextureFlags.hasEmissive)m_Properties.emissive = glm::vec3(1.0f);
 
         m_Shader = s_StandardShader;
 
@@ -83,18 +77,18 @@ namespace Coffee {
         m_Shader->Unbind();
     }
 
-    Material::Material(ImportData& importData)
-        : Resource(ResourceType::Material)
+    PBRMaterial::PBRMaterial(ImportData& importData)
+        : Material(ResourceType::PBRMaterial)
     {
-        MaterialImportData& materialImportData = dynamic_cast<MaterialImportData&>(importData);
+        PBRMaterialImportData& materialImportData = dynamic_cast<PBRMaterialImportData&>(importData);
 
         if(materialImportData.materialTextures)
         {
-            *this = Material(m_Name, *materialImportData.materialTextures);
+            *this = PBRMaterial(m_Name, *materialImportData.materialTextures);
         }
         else
         {
-            *this = Material(m_Name);
+            *this = PBRMaterial(m_Name);
         }
 
         m_Name = materialImportData.name;
@@ -102,55 +96,55 @@ namespace Coffee {
         m_FilePath = materialImportData.cachedPath;
     }
 
-    void Material::Use()
+    void PBRMaterial::Use()
     {
         ZoneScoped;
 
         // Update Texture Flags
-        m_MaterialTextureFlags.hasAlbedo = (m_MaterialTextures.albedo != nullptr);
-        m_MaterialTextureFlags.hasNormal = (m_MaterialTextures.normal != nullptr);
-        m_MaterialTextureFlags.hasMetallic = (m_MaterialTextures.metallic != nullptr);
-        m_MaterialTextureFlags.hasRoughness = (m_MaterialTextures.roughness != nullptr);
-        m_MaterialTextureFlags.hasAO = (m_MaterialTextures.ao != nullptr);
-        m_MaterialTextureFlags.hasEmissive = (m_MaterialTextures.emissive != nullptr);
+        m_TextureFlags.hasAlbedo = (m_Textures.albedo != nullptr);
+        m_TextureFlags.hasNormal = (m_Textures.normal != nullptr);
+        m_TextureFlags.hasMetallic = (m_Textures.metallic != nullptr);
+        m_TextureFlags.hasRoughness = (m_Textures.roughness != nullptr);
+        m_TextureFlags.hasAO = (m_Textures.ao != nullptr);
+        m_TextureFlags.hasEmissive = (m_Textures.emissive != nullptr);
 
         m_Shader->Bind();
 
         // Bind Textures
-        if(m_MaterialTextureFlags.hasAlbedo)m_MaterialTextures.albedo->Bind(0);
-        if(m_MaterialTextureFlags.hasNormal)m_MaterialTextures.normal->Bind(1);
-        if(m_MaterialTextureFlags.hasMetallic)m_MaterialTextures.metallic->Bind(2);
-        if(m_MaterialTextureFlags.hasRoughness)m_MaterialTextures.roughness->Bind(3);
-        if(m_MaterialTextureFlags.hasAO)m_MaterialTextures.ao->Bind(4);
-        if(m_MaterialTextureFlags.hasEmissive)m_MaterialTextures.emissive->Bind(5);
+        if(m_TextureFlags.hasAlbedo)m_Textures.albedo->Bind(0);
+        if(m_TextureFlags.hasNormal)m_Textures.normal->Bind(1);
+        if(m_TextureFlags.hasMetallic)m_Textures.metallic->Bind(2);
+        if(m_TextureFlags.hasRoughness)m_Textures.roughness->Bind(3);
+        if(m_TextureFlags.hasAO)m_Textures.ao->Bind(4);
+        if(m_TextureFlags.hasEmissive)m_Textures.emissive->Bind(5);
 
         // Set Material Properties
-        m_Shader->setVec4("material.color", m_MaterialProperties.color);
-        m_Shader->setFloat("material.metallic", m_MaterialProperties.metallic);
-        m_Shader->setFloat("material.roughness", m_MaterialProperties.roughness);
-        m_Shader->setFloat("material.ao", m_MaterialProperties.ao);
-        m_Shader->setVec3("material.emissive", m_MaterialProperties.emissive);
+        m_Shader->setVec4("material.color", m_Properties.color);
+        m_Shader->setFloat("material.metallic", m_Properties.metallic);
+        m_Shader->setFloat("material.roughness", m_Properties.roughness);
+        m_Shader->setFloat("material.ao", m_Properties.ao);
+        m_Shader->setVec3("material.emissive", m_Properties.emissive);
 
         // Set Material Texture Flags
-        m_Shader->setInt("material.hasAlbedo", m_MaterialTextureFlags.hasAlbedo);
-        m_Shader->setInt("material.hasNormal", m_MaterialTextureFlags.hasNormal);
-        m_Shader->setInt("material.hasMetallic", m_MaterialTextureFlags.hasMetallic);
-        m_Shader->setInt("material.hasRoughness", m_MaterialTextureFlags.hasRoughness);
-        m_Shader->setInt("material.hasAO", m_MaterialTextureFlags.hasAO);
-        m_Shader->setInt("material.hasEmissive", m_MaterialTextureFlags.hasEmissive);
+        m_Shader->setInt("material.hasAlbedo", m_TextureFlags.hasAlbedo);
+        m_Shader->setInt("material.hasNormal", m_TextureFlags.hasNormal);
+        m_Shader->setInt("material.hasMetallic", m_TextureFlags.hasMetallic);
+        m_Shader->setInt("material.hasRoughness", m_TextureFlags.hasRoughness);
+        m_Shader->setInt("material.hasAO", m_TextureFlags.hasAO);
+        m_Shader->setInt("material.hasEmissive", m_TextureFlags.hasEmissive);
 
-        m_Shader->setInt("material.transparencyMode", m_MaterialRenderSettings.transparencyMode);
-        m_Shader->setFloat("material.alphaCutoff", m_MaterialRenderSettings.alphaCutoff);
+        m_Shader->setInt("material.transparencyMode", m_RenderSettings.transparencyMode);
+        m_Shader->setFloat("material.alphaCutoff", m_RenderSettings.alphaCutoff);
     }
 
-    Ref<Material> Material::Create(const std::string& name, MaterialTextures* materialTextures)
+    Ref<PBRMaterial> PBRMaterial::Create(const std::string& name, PBRMaterialTextures* materialTextures)
     {
-        MaterialImportData importData;
+        PBRMaterialImportData importData;
         importData.name = name;
         importData.materialTextures = materialTextures;
         importData.uuid = UUID();
         importData.cachedPath = CacheManager::GetCachedFilePath(importData.uuid, ResourceType::Material);
 
-        return ResourceLoader::LoadEmbedded<Material>(importData);
+        return ResourceLoader::LoadEmbedded<PBRMaterial>(importData);
     }
 }

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.cpp
@@ -178,7 +178,7 @@ namespace Coffee {
         importData.name = name;
         importData.materialTextures = materialTextures;
         importData.uuid = UUID();
-        importData.cachedPath = CacheManager::GetCachedFilePath(importData.uuid, ResourceType::Material);
+        importData.cachedPath = CacheManager::GetCachedFilePath(importData.uuid, ResourceType::PBRMaterial);
 
         return ResourceLoader::LoadEmbedded<PBRMaterial>(importData);
     }

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -7,6 +7,7 @@
 #include "CoffeeEngine/Renderer/Texture.h"
 #include "CoffeeEngine/IO/ResourceLoader.h"
 #include "CoffeeEngine/IO/Serialization/GLMSerialization.h"
+#include <cereal/cereal.hpp>
 #include <cereal/types/polymorphic.hpp>
 #include <filesystem>
 #include <glm/fwd.hpp>
@@ -67,7 +68,14 @@ namespace Coffee {
          template<class Archive>
          void serialize(Archive& archive)
          {
-             archive(transparencyMode, alphaCutoff, blendMode, cullMode, depthTest, wireframe);
+            archive(
+                cereal::make_nvp("TransparencyMode", transparencyMode),
+                cereal::make_nvp("AlphaCutoff", alphaCutoff),
+                cereal::make_nvp("BlendMode", blendMode),
+                cereal::make_nvp("CullMode", cullMode),
+                cereal::make_nvp("DepthTest", depthTest),
+                cereal::make_nvp("Wireframe", wireframe)
+            );
          }
      };
 
@@ -92,12 +100,15 @@ namespace Coffee {
         template<class Archive>
         void save(Archive& archive) const
         {
-            archive(cereal::base_class<Resource>(this), m_RenderSettings);
+            std::string shaderPath = m_Shader ? m_Shader->GetPath() : "";
+            archive(cereal::base_class<Resource>(this), cereal::make_nvp("Shader Path", shaderPath), cereal::make_nvp("Render Settings", m_RenderSettings));
         }
         template<class Archive>
         void load(Archive& archive)
         {
-            archive(cereal::base_class<Resource>(this), m_RenderSettings);
+            std::string shaderPath;
+            archive(cereal::base_class<Resource>(this), cereal::make_nvp("Shader Path", shaderPath), cereal::make_nvp("Render Settings", m_RenderSettings));
+            if (!shaderPath.empty()) m_Shader = Shader::Create(shaderPath);
         }
     protected:
         Ref<Shader> m_Shader; ///< The shader used by the material.
@@ -124,15 +135,13 @@ namespace Coffee {
         template<class Archive>
         void save(Archive& archive) const
         {
-            archive(m_Shader->GetPath(), cereal::base_class<Material>(this));
+            archive(cereal::base_class<Material>(this));
         }
 
         template<class Archive>
         void load(Archive& archive)
         {
-            std::string shaderPath;
-            archive(shaderPath, cereal::base_class<Material>(this));
-            m_Shader = Shader::Create(shaderPath);
+            archive(cereal::base_class<Material>(this));
         }
     private:
     };
@@ -154,7 +163,13 @@ namespace Coffee {
             template<class Archive>
             void serialize(Archive& archive)
             {
-                archive(color, metallic, roughness, ao, emissive);
+                archive(
+                    cereal::make_nvp("Color", color),
+                    cereal::make_nvp("Metallic", metallic),
+                    cereal::make_nvp("Roughness", roughness),
+                    cereal::make_nvp("AO", ao),
+                    cereal::make_nvp("Emissive", emissive)
+                );
             }
     };
 
@@ -176,21 +191,28 @@ namespace Coffee {
             template<class Archive>
             void save(Archive& archive) const
             {
-                UUID albedoUUID = albedo ? albedo->GetUUID() : UUID::null;
-                UUID normalUUID = normal ? normal->GetUUID() : UUID::null;
-                UUID metallicUUID = metallic ? metallic->GetUUID() : UUID::null;
-                UUID roughnessUUID = roughness ? roughness->GetUUID() : UUID::null;
-                UUID aoUUID = ao ? ao->GetUUID() : UUID::null;
-                UUID emissiveUUID = emissive ? emissive->GetUUID() : UUID::null;
-
-                archive(albedoUUID, normalUUID, metallicUUID, roughnessUUID, aoUUID, emissiveUUID);
+                archive(
+                    cereal::make_nvp("AlbedoUUID", albedo ? albedo->GetUUID() : UUID::null),
+                    cereal::make_nvp("NormalUUID", normal ? normal->GetUUID() : UUID::null),
+                    cereal::make_nvp("MetallicUUID", metallic ? metallic->GetUUID() : UUID::null),
+                    cereal::make_nvp("RoughnessUUID", roughness ? roughness->GetUUID() : UUID::null),
+                    cereal::make_nvp("AOUUID", ao ? ao->GetUUID() : UUID::null),
+                    cereal::make_nvp("EmissiveUUID", emissive ? emissive->GetUUID() : UUID::null)
+                );
             }
 
             template<class Archive>
             void load(Archive& archive)
             {
                 UUID albedoUUID, normalUUID, metallicUUID, roughnessUUID, aoUUID, emissiveUUID;
-                archive(albedoUUID, normalUUID, metallicUUID, roughnessUUID, aoUUID, emissiveUUID);
+                archive(
+                    cereal::make_nvp("AlbedoUUID", albedoUUID),
+                    cereal::make_nvp("NormalUUID", normalUUID),
+                    cereal::make_nvp("MetallicUUID", metallicUUID),
+                    cereal::make_nvp("RoughnessUUID", roughnessUUID),
+                    cereal::make_nvp("AOUUID", aoUUID),
+                    cereal::make_nvp("EmissiveUUID", emissiveUUID)
+                );
 
                 albedo = ResourceLoader::GetResource<Texture2D>(albedoUUID);
                 normal = ResourceLoader::GetResource<Texture2D>(normalUUID);
@@ -216,7 +238,14 @@ namespace Coffee {
             template<class Archive>
             void serialize(Archive& archive)
             {
-                archive(hasAlbedo, hasNormal, hasMetallic, hasRoughness, hasAO, hasEmissive);
+                archive(
+                    cereal::make_nvp("HasAlbedo", hasAlbedo),
+                    cereal::make_nvp("HasNormal", hasNormal),
+                    cereal::make_nvp("HasMetallic", hasMetallic),
+                    cereal::make_nvp("HasRoughness", hasRoughness),
+                    cereal::make_nvp("HasAO", hasAO),
+                    cereal::make_nvp("HasEmissive", hasEmissive)
+                );
             }
     };
 
@@ -267,13 +296,23 @@ namespace Coffee {
         template<class Archive>
         void save(Archive& archive) const
         {
-            archive(m_Textures, m_TextureFlags, m_Properties, m_RenderSettings, cereal::base_class<Material>(this));
+            archive(
+                cereal::make_nvp("Textures", m_Textures),
+                cereal::make_nvp("TextureFlags", m_TextureFlags),
+                cereal::make_nvp("Properties", m_Properties),
+                cereal::base_class<Material>(this)
+            );
         }
-
+        
         template<class Archive>
         void load(Archive& archive)
         {
-            archive(m_Textures, m_TextureFlags, m_Properties, m_RenderSettings, cereal::base_class<Material>(this));
+            archive(
+                cereal::make_nvp("Textures", m_Textures),
+                cereal::make_nvp("TextureFlags", m_TextureFlags),
+                cereal::make_nvp("Properties", m_Properties),
+                cereal::base_class<Material>(this)
+            );
         }
 
         template<class Archive>
@@ -282,13 +321,17 @@ namespace Coffee {
             PBRMaterialTextures PBRMaterialTextures;
             PBRMaterialTextureFlags PBRMaterialTextureFlags;
             PBRMaterialProperties PBRMaterialProperties;
+            PBRMaterial tmpMaterial;
 
-            archive(PBRMaterialTextures, PBRMaterialTextureFlags, PBRMaterialProperties, cereal::base_class<Material>(construct.ptr()));
+            archive(PBRMaterialTextures, PBRMaterialTextureFlags, PBRMaterialProperties, cereal::base_class<Material>(&tmpMaterial));
 
-            // TODO: TEST THE GETNAME PART PLEASE!!
-            construct(construct.ptr()->GetName(), PBRMaterialTextures);
+            construct(tmpMaterial.GetName(), PBRMaterialTextures);
             construct->m_TextureFlags = PBRMaterialTextureFlags;
             construct->m_Properties = PBRMaterialProperties;
+            construct->m_Name = tmpMaterial.GetName();
+            construct->m_FilePath = tmpMaterial.GetPath();
+            construct->m_Type = tmpMaterial.GetType();
+            construct->m_UUID = tmpMaterial.GetUUID();
         }
 
     private:

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -107,7 +107,7 @@ namespace Coffee {
             if (Project::GetActive())
                 shaderPath = std::filesystem::relative(m_Shader->GetPath(), Project::GetActive()->GetProjectDirectory());
             else
-                COFFEE_CORE_ERROR("Material::save: Project is not active, shader path is not relative to the project directory!");
+                shaderPath = m_Shader->GetPath();
 
             archive(cereal::base_class<Resource>(this), cereal::make_nvp("Shader Path", shaderPath.generic_string()), cereal::make_nvp("Render Settings", m_RenderSettings));
         }
@@ -120,7 +120,7 @@ namespace Coffee {
             if (Project::GetActive())
                 shaderPath = Project::GetActive()->GetProjectDirectory() / shaderPath;
             else
-                COFFEE_CORE_ERROR("Material::load: Project is not active, shader path is not relative to the project directory!");
+                shaderPath = shaderPath;
 
             if (!shaderPath.empty() and std::filesystem::is_regular_file(shaderPath)) m_Shader = Shader::Create(shaderPath);
         }

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -102,14 +102,14 @@ namespace Coffee {
         template<class Archive>
         void save(Archive& archive) const
         {
-            std::string shaderPath = m_Shader ? m_Shader->GetPath() : "";
+            std::filesystem::path shaderPath = m_Shader ? m_Shader->GetPath() : "";
             
             if (Project::GetActive())
                 shaderPath = std::filesystem::relative(m_Shader->GetPath(), Project::GetActive()->GetProjectDirectory());
             else
                 COFFEE_CORE_ERROR("Material::save: Project is not active, shader path is not relative to the project directory!");
 
-            archive(cereal::base_class<Resource>(this), cereal::make_nvp("Shader Path", shaderPath), cereal::make_nvp("Render Settings", m_RenderSettings));
+            archive(cereal::base_class<Resource>(this), cereal::make_nvp("Shader Path", shaderPath.generic_string()), cereal::make_nvp("Render Settings", m_RenderSettings));
         }
         template<class Archive>
         void load(Archive& archive)

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -111,6 +111,8 @@ namespace Coffee {
 
         ShaderMaterial(const std::string& name, Ref<Shader> shader) : Material(name, shader) {}
 
+        ShaderMaterial(ImportData& importData);
+
         void Use() override;
 
         static Ref<ShaderMaterial> Create(const std::string& name = "", Ref<Shader> shader = nullptr);
@@ -120,13 +122,15 @@ namespace Coffee {
         template<class Archive>
         void save(Archive& archive) const
         {
-            archive(cereal::base_class<Material>(this));
+            archive(m_Shader->GetPath(), cereal::base_class<Material>(this));
         }
 
         template<class Archive>
         void load(Archive& archive)
         {
-            archive(cereal::base_class<Material>(this));
+            std::string shaderPath;
+            archive(shaderPath, cereal::base_class<Material>(this));
+            m_Shader = Shader::Create(shaderPath);
         }
     private:
     };

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -23,19 +23,53 @@ namespace Coffee {
     // Not implemented yet!!
     struct MaterialRenderSettings
     {
-        bool wireframe = false;
-        bool depthTest = true;
-        bool depthWrite = true;
-        bool faceCulling = true;
+        // Transparency
+        enum TransparencyMode
+        {
+            Disabled = 0,
+            Alpha,
+            AlphaCutoff
+        } transparencyMode = TransparencyMode::Disabled; ///< The transparency mode.
 
-        private:
-            friend class cereal::access;
+        float alphaCutoff = 0.5f; ///< The alpha cutoff value for the transparency mode.
 
-            template<class Archive>
-            void serialize(Archive& archive)
-            {
-                archive(wireframe, depthTest, depthWrite, faceCulling);
-            }
+        // Blend mode
+        enum BlendMode
+        {
+            Mix = 0,
+            Add,
+            Subtract,
+            Multiply
+        } blendMode = BlendMode::Mix; ///< The blend mode for the transparency.
+
+        // Culling
+        enum CullMode
+        {
+            Front = 0,
+            Back,
+            None
+        } cullMode = CullMode::Back; ///< The culling mode for the material.
+
+        // Depth
+/*         enum DepthMode
+        {
+            Read = 0,
+            Write,
+            None
+        } depthMode = DepthMode::Write; ///< The depth mode for the material. */
+        bool depthTest = true; ///< Whether to enable depth testing.
+
+        // Wireframe
+        bool wireframe = false; ///< Whether to render the material in wireframe mode.
+        
+    private:
+        friend class cereal::access;
+
+        template<class Archive>
+        void serialize(Archive& archive)
+        {
+            archive(transparencyMode, alphaCutoff, blendMode, cullMode, depthTest, wireframe);
+        }
     };
 
     /**
@@ -173,6 +207,7 @@ namespace Coffee {
 
         MaterialTextures& GetMaterialTextures() { return m_MaterialTextures; }
         MaterialProperties& GetMaterialProperties() { return m_MaterialProperties; }
+        MaterialRenderSettings& GetMaterialRenderSettings() { return m_MaterialRenderSettings; }
 
         //TODO: Remove the materialTextures parameter and make a function that set the materialTextures and the shader too
         static Ref<Material> Create(const std::string& name = "", MaterialTextures* materialTextures = nullptr);

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -80,7 +80,7 @@ namespace Coffee {
 
         Material(const std::string& name, ResourceType type) : Resource(type) { m_Name = name; }
 
-        Material(const std::string& name, Ref<Shader> shader) : Resource(ResourceType::Material), m_Shader(shader) { m_Name = name; }
+        Material(const std::string& name, Ref<Shader> shader, ResourceType type) : Resource(type), m_Shader(shader) { m_Name = name; }
 
         Ref<Shader> GetShader() { return m_Shader; }
         MaterialRenderSettings& GetRenderSettings() { return m_RenderSettings; }
@@ -109,11 +109,13 @@ namespace Coffee {
     public:
         ShaderMaterial() : Material(ResourceType::ShaderMaterial) {}
 
-        ShaderMaterial(const std::string& name, Ref<Shader> shader) : Material(name, shader) {}
+        ShaderMaterial(const std::string& name, Ref<Shader> shader) : Material(name, shader, ResourceType::ShaderMaterial) {}
 
         ShaderMaterial(ImportData& importData);
 
         void Use() override;
+
+        void SetShader(Ref<Shader> shader) { m_Shader = shader; }
 
         static Ref<ShaderMaterial> Create(const std::string& name = "", Ref<Shader> shader = nullptr);
     private:
@@ -304,3 +306,5 @@ CEREAL_REGISTER_TYPE(Coffee::Material);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Coffee::Resource, Coffee::Material);
 CEREAL_REGISTER_TYPE(Coffee::PBRMaterial);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Coffee::Material, Coffee::PBRMaterial);
+CEREAL_REGISTER_TYPE(Coffee::ShaderMaterial);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(Coffee::Material, Coffee::ShaderMaterial);

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Material.h
@@ -104,6 +104,33 @@ namespace Coffee {
         MaterialRenderSettings m_RenderSettings; ///< The render settings for the material.
     };
 
+    class ShaderMaterial : public Material
+    {
+    public:
+        ShaderMaterial() : Material(ResourceType::ShaderMaterial) {}
+
+        ShaderMaterial(const std::string& name, Ref<Shader> shader) : Material(name, shader) {}
+
+        void Use() override;
+
+        static Ref<ShaderMaterial> Create(const std::string& name = "", Ref<Shader> shader = nullptr);
+    private:
+        friend class cereal::access;
+
+        template<class Archive>
+        void save(Archive& archive) const
+        {
+            archive(cereal::base_class<Material>(this));
+        }
+
+        template<class Archive>
+        void load(Archive& archive)
+        {
+            archive(cereal::base_class<Material>(this));
+        }
+    private:
+    };
+
     /**
      * @brief Structure representing the properties of a PBRMaterial.
      */

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Mesh.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Mesh.h
@@ -142,7 +142,7 @@ namespace Coffee {
             UUID materialUUID;
             archive(m_Vertices, m_Indices, m_AABB, materialUUID, cereal::base_class<Resource>(this));
 
-            m_Material = ResourceLoader::GetResource<Material>(materialUUID);
+            m_Material = ResourceLoader::GetResource<PBRMaterial>(materialUUID);
         }
 
         template<class Archive>
@@ -159,7 +159,7 @@ namespace Coffee {
             data(construct->m_AABB, materialUUID, cereal::base_class<Resource>(construct.ptr()));
             construct->m_Vertices = vertices;
             construct->m_Indices = indices;
-            construct->m_Material = ResourceLoader::GetResource<Material>(materialUUID);
+            construct->m_Material = ResourceLoader::GetResource<PBRMaterial>(materialUUID);
         }
       private:
         Ref<VertexArray> m_VertexArray; ///< The vertex array of the mesh.

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Model.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Model.cpp
@@ -250,19 +250,19 @@ namespace Coffee {
                 s_ModelMaterialsUUIDs[referenceName] = materialUUID;
             }
 
-            MaterialTextures matTextures = LoadMaterialTextures(material);
+            PBRMaterialTextures matTextures = LoadMaterialTextures(material);
 
-            MaterialImportData materialImportData;
+            PBRMaterialImportData materialImportData;
             materialImportData.name = referenceName;
             materialImportData.materialTextures = &matTextures;
             materialImportData.uuid = materialUUID;
-            materialImportData.cachedPath = CacheManager::GetCachedFilePath(materialUUID, ResourceType::Material);
+            materialImportData.cachedPath = CacheManager::GetCachedFilePath(materialUUID, ResourceType::PBRMaterial);
             
-            meshMaterial = ResourceLoader::LoadEmbedded<Material>(materialImportData);
+            meshMaterial = ResourceLoader::LoadEmbedded<PBRMaterial>(materialImportData);
         }
         else
         {
-            meshMaterial = Material::Create();
+            meshMaterial = PBRMaterial::Create();
         }
 
         AABB aabb(
@@ -371,9 +371,9 @@ namespace Coffee {
         return Texture2D::Load(texturePath);
     }
 
-    MaterialTextures Model::LoadMaterialTextures(aiMaterial* material)
+    PBRMaterialTextures Model::LoadMaterialTextures(aiMaterial* material)
     {
-        MaterialTextures matTextures;
+        PBRMaterialTextures matTextures;
 
         matTextures.albedo = LoadTexture2D(material, aiTextureType_DIFFUSE);
         matTextures.normal = LoadTexture2D(material, aiTextureType_NORMALS);

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Model.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Model.h
@@ -166,7 +166,7 @@ namespace Coffee {
          * @param material The Assimp material.
          * @return The loaded material textures.
          */
-        MaterialTextures LoadMaterialTextures(aiMaterial* material);
+        PBRMaterialTextures LoadMaterialTextures(aiMaterial* material);
         
         friend class cereal::access;
         template<class Archive>

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer.cpp
@@ -45,6 +45,7 @@ namespace Coffee {
             Renderer3D::ShadowPass(target);
             Renderer3D::ForwardPass(target);
             Renderer3D::SkyboxPass(target);
+            Renderer3D::TransparentPass(target);
 
             if(s_RenderSettings.PostProcessing)
             {

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
@@ -262,7 +262,7 @@ namespace Coffee {
         {
             Material* material = command.material.get();
 
-            if(material == nullptr)
+            if(material == nullptr or material->GetShader() == nullptr)
             {
                 material = s_RendererData.DefaultMaterial.get();
             }

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
@@ -57,7 +57,8 @@ namespace Coffee {
         s_RendererData.SceneRenderDataUniformBuffer = UniformBuffer::Create(sizeof(Renderer3DData::RenderData), 1);
 
         Ref<Shader> missingShader = CreateRef<Shader>("MissingShader", std::string(missingShaderSource));
-        s_RendererData.DefaultMaterial = nullptr;/* CreateRef<Material>("Missing Material", missingShader); //TODO: Port it to use the Material::Create and use ShaderMaterial */
+        s_RendererData.DefaultMaterial = ShaderMaterial::Create("Missing Material", missingShader);
+        //s_RendererData.DefaultMaterial = nullptr;/* CreateRef<Material>("Missing Material", missingShader); //TODO: Port it to use the Material::Create and use ShaderMaterial */
 
         // TODO: This is a hack to get the missing mesh add it to the PrimitiveMesh class
         Ref<Model> m = Model::Load("assets/models/MissingMesh.glb");
@@ -393,6 +394,7 @@ namespace Coffee {
 
         const Ref<Framebuffer>& forwardBuffer = target.GetFramebuffer("Forward");
         forwardBuffer->Bind();
+        forwardBuffer->SetDrawBuffers({0, 1}); //TODO: This should only be done in the editor
 
         // Bind the irradiance map
         s_EnvironmentMap->BindIrradianceMap(6);

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
@@ -407,6 +407,8 @@ namespace Coffee {
             return distA > distB;
         });
 
+        RendererAPI::SetDepthMask(false);
+
         for (const auto& command : s_RendererData.transparentRenderQueue)
         {
             Material* material = command.material.get();
@@ -468,15 +470,6 @@ namespace Coffee {
                         break;
                 }
     
-                if (settings.depthTest)
-                {
-                    RendererAPI::SetDepthMask(true);
-                }
-                else
-                {
-                    RendererAPI::SetDepthMask(false);
-                }
-    
                 if (settings.wireframe)
                 {
                     RendererAPI::SetPolygonMode(PolygonMode::Line);
@@ -488,6 +481,8 @@ namespace Coffee {
 
             RendererAPI::DrawIndexed(mesh->GetVertexArray());
         }
+
+        RendererAPI::SetDepthMask(true);
 
         forwardBuffer->UnBind();
 

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.cpp
@@ -57,7 +57,7 @@ namespace Coffee {
         s_RendererData.SceneRenderDataUniformBuffer = UniformBuffer::Create(sizeof(Renderer3DData::RenderData), 1);
 
         Ref<Shader> missingShader = CreateRef<Shader>("MissingShader", std::string(missingShaderSource));
-        s_RendererData.DefaultMaterial = CreateRef<Material>("Missing Material", missingShader); //TODO: Port it to use the Material::Create
+        s_RendererData.DefaultMaterial = nullptr;/* CreateRef<Material>("Missing Material", missingShader); //TODO: Port it to use the Material::Create and use ShaderMaterial */
 
         // TODO: This is a hack to get the missing mesh add it to the PrimitiveMesh class
         Ref<Model> m = Model::Load("assets/models/MissingMesh.glb");
@@ -87,7 +87,7 @@ namespace Coffee {
             return;
         }
 
-        const auto& settings = command.material->GetMaterialRenderSettings();
+        const auto& settings = command.material->GetRenderSettings();
 
         if (settings.transparencyMode == MaterialRenderSettings::TransparencyMode::Disabled)
         {
@@ -317,7 +317,7 @@ namespace Coffee {
             }
 
             // Apply material settings
-            const MaterialRenderSettings& settings = material->GetMaterialRenderSettings();
+            const MaterialRenderSettings& settings = material->GetRenderSettings();
             switch (settings.cullMode)
             {
                 case MaterialRenderSettings::CullMode::Front:
@@ -456,7 +456,7 @@ namespace Coffee {
             }
 
                 // Apply material settings
-                const MaterialRenderSettings& settings = material->GetMaterialRenderSettings();
+                const MaterialRenderSettings& settings = material->GetRenderSettings();
                 switch (settings.cullMode)
                 {
                     case MaterialRenderSettings::CullMode::Front:

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.h
@@ -23,10 +23,10 @@ namespace Coffee {
 
     struct RenderCommand
     {
-        glm::mat4 transform;
+        glm::mat4 transform = glm::mat4(1.0f);
         Ref<Mesh> mesh;
         Ref<Material> material;
-        uint32_t entityID;
+        uint32_t entityID = 4294967295;
         AnimatorComponent* animator;
     };
 

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer3D.h
@@ -55,7 +55,8 @@ namespace Coffee {
         static constexpr int MAX_DIRECTIONAL_SHADOWS = 4;
         Ref<Texture2D> DirectionalShadowMapTextures[4];
 
-        std::vector<RenderCommand> renderQueue; ///< Render queue.
+        std::vector<RenderCommand> opaqueRenderQueue; ///< Opaque render queue.
+        std::vector<RenderCommand> transparentRenderQueue; ///< Transparent render queue.
     };
 
     /**
@@ -122,6 +123,7 @@ namespace Coffee {
         static void ShadowPass(const RenderTarget& target);
         static void ForwardPass(const RenderTarget& target);
         static void SkyboxPass(const RenderTarget& target);
+        static void TransparentPass(const RenderTarget& target);
         static void PostProcessingPass(const RenderTarget& target);
 
         /**

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/RendererAPI.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/RendererAPI.cpp
@@ -108,6 +108,19 @@ namespace Coffee {
 		}
 	}
 
+	void RendererAPI::SetPolygonMode(PolygonMode mode)
+	{
+		ZoneScoped;
+
+		switch (mode)
+		{
+			case PolygonMode::Fill: glPolygonMode(GL_FRONT_AND_BACK, GL_FILL); break;
+			case PolygonMode::Line: glPolygonMode(GL_FRONT_AND_BACK, GL_LINE); break;
+			case PolygonMode::Point: glPolygonMode(GL_FRONT_AND_BACK, GL_POINT); break;
+			default: COFFEE_CORE_ASSERT(false, "Unknown polygon mode!"); break;
+		}
+	}
+
     void RendererAPI::DrawIndexed(const Ref<VertexArray>& vertexArray, uint32_t indexCount)
     {
         ZoneScoped;

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/RendererAPI.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/RendererAPI.h
@@ -20,6 +20,13 @@ namespace Coffee {
         FrontAndBack = 2
      };
 
+        enum class PolygonMode
+        {
+            Fill = 0,
+            Line = 1,
+            Point = 2
+        };
+
     /**
      * @brief Class representing the Renderer API.
      */
@@ -52,6 +59,8 @@ namespace Coffee {
         static void SetFaceCulling(bool enabled);
 
         static void SetCullFace(CullFace face);
+
+        static void SetPolygonMode(PolygonMode mode);
 
         /**
          * @brief Draws the indexed vertices from the specified vertex array.

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Shader.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Shader.cpp
@@ -144,6 +144,14 @@ namespace Coffee {
         glUniformMatrix4fv(location, matrices.size(), GL_FALSE, &matrices[0][0][0]);
     }
 
+    void Shader::Recompile()
+    {
+        ZoneScoped;
+
+        std::string shaderCode = ReadShaderFile(m_FilePath);
+        CompileShader(shaderCode);
+    }
+
     Ref<Shader> Shader::Create(const std::filesystem::path& shaderPath)
     {
         ZoneScoped;

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Shader.h
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Shader.h
@@ -115,6 +115,8 @@ namespace Coffee {
 
         void setMat4v(const std::string& name, const std::vector<glm::mat4>& matrices) const;
 
+        void Recompile();
+
         /**
          * @brief Creates a shader from the specified vertex and fragment shader paths.
          * @param vertexPath The file path to the vertex shader.

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
@@ -6,6 +6,7 @@
  #pragma once
 
  #include "CoffeeEngine/Core/Base.h"
+#include "CoffeeEngine/IO/Resource.h"
  #include "CoffeeEngine/IO/ResourceLoader.h"
  #include "CoffeeEngine/IO/ResourceRegistry.h"
  #include "CoffeeEngine/Physics/Collider.h"
@@ -489,17 +490,73 @@
           */
          template<class Archive> void save(Archive& archive, std::uint32_t const version) const
          {
-            ResourceSaver::SaveToCache<Material>(material->GetUUID(), material);
-            archive(cereal::make_nvp("Material", material->GetUUID()));
+            if (version < 1)
+            {
+                archive(cereal::make_nvp("Material", material->GetUUID()));
+                return;
+            }
+            
+            archive(cereal::make_nvp("IsEmbedded", material->IsEmbedded()));
+            if (material->IsEmbedded())
+            {
+                archive(cereal::make_nvp("Material", material));
+            }
+            else 
+            {
+                archive(cereal::make_nvp("Type", static_cast<int>(material->GetType())));
+                
+                if (material->GetType() == ResourceType::PBRMaterial)
+                {
+                    ResourceSaver::SaveToCache<PBRMaterial>(material->GetUUID(), std::dynamic_pointer_cast<PBRMaterial>(material));
+                }
+                else if (material->GetType() == ResourceType::ShaderMaterial)
+                {
+                    ResourceSaver::SaveToCache<ShaderMaterial>(material->GetUUID(), std::dynamic_pointer_cast<ShaderMaterial>(material));
+                }
+
+                archive(cereal::make_nvp("MaterialUUID", material->GetUUID()));
+            }
          }
  
          template<class Archive> void load(Archive& archive, std::uint32_t const version)
          {
-             UUID materialUUID;
-             archive(cereal::make_nvp("Material", materialUUID));
+            if (version < 1)
+            {
+                UUID materialUUID;
+                archive(cereal::make_nvp("Material", materialUUID));
  
-             Ref<Material> material = ResourceLoader::GetResource<Material>(materialUUID);
-             this->material = material;
+                Ref<Material> material = ResourceLoader::GetResource<Material>(materialUUID);
+                this->material = material;
+                return;
+            }
+
+            bool isEmbedded = false;
+            archive(cereal::make_nvp("IsEmbedded", isEmbedded));
+
+            if (isEmbedded)
+            {
+                archive(cereal::make_nvp("Material", material));
+            }
+            else 
+            {
+                int typeInt;
+                archive(cereal::make_nvp("Type", typeInt));
+                ResourceType type = static_cast<ResourceType>(typeInt);
+
+                UUID materialUUID;
+                archive(cereal::make_nvp("MaterialUUID", materialUUID));
+ 
+                if (type == ResourceType::PBRMaterial)
+                {
+                    Ref<PBRMaterial> material = ResourceLoader::GetResource<PBRMaterial>(materialUUID);
+                    this->material = material;
+                }
+                else if (type == ResourceType::ShaderMaterial)
+                {
+                    Ref<ShaderMaterial> material = ResourceLoader::GetResource<ShaderMaterial>(materialUUID);
+                    this->material = material;
+                }
+            }
          }
      };
  
@@ -1347,7 +1404,7 @@
  CEREAL_CLASS_VERSION(Coffee::CameraComponent, 0);
  CEREAL_CLASS_VERSION(Coffee::AnimatorComponent, 0);
  CEREAL_CLASS_VERSION(Coffee::MeshComponent, 0);
- CEREAL_CLASS_VERSION(Coffee::MaterialComponent, 0);
+ CEREAL_CLASS_VERSION(Coffee::MaterialComponent, 1);
  CEREAL_CLASS_VERSION(Coffee::LightComponent, 1);
  CEREAL_CLASS_VERSION(Coffee::AudioSourceComponent, 0);
  CEREAL_CLASS_VERSION(Coffee::AudioListenerComponent, 0);

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaEntity.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaEntity.cpp
@@ -34,7 +34,7 @@ void Coffee::RegisterEntityBindings(sol::state& luaState)
                     return sol::nil;
                 } else if (componentName == "MaterialComponent") {
                     if (auto* component = self->TryGetComponent<MaterialComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
                     COFFEE_CORE_ERROR("Lua: Entity does not have a MaterialComponent");
                     return sol::nil;
                 } else if (componentName == "LightComponent") {

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaEntity.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaEntity.cpp
@@ -9,26 +9,26 @@ void Coffee::RegisterEntityBindings(sol::state& luaState)
             "get_component", [&luaState](Entity* self, const std::string& componentName) -> sol::object {
                 if (componentName == "TagComponent") {
                     if (auto* component = self->TryGetComponent<TagComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a TagComponent");
                     return sol::nil;
                 } else if (componentName == "TransformComponent") {
                     if (auto* component = self->TryGetComponent<TransformComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a TransformComponent");
                     return sol::nil;
                 } else if (componentName == "CameraComponent") {
                     if (auto* component = self->TryGetComponent<CameraComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a CameraComponent");
                     return sol::nil;
                 } else if (componentName == "MeshComponent") {
                     if (auto* component = self->TryGetComponent<MeshComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a MeshComponent");
                     return sol::nil;
@@ -39,73 +39,73 @@ void Coffee::RegisterEntityBindings(sol::state& luaState)
                     return sol::nil;
                 } else if (componentName == "LightComponent") {
                     if (auto* component = self->TryGetComponent<LightComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a LightComponent");
                     return sol::nil;
                 } else if (componentName == "ScriptComponent") {
                     if (auto* component = self->TryGetComponent<ScriptComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a ScriptComponent");
                     return sol::nil;
                 } else if (componentName == "ParticlesSystemComponent") {
                     if (auto* component = self->TryGetComponent<ParticlesSystemComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a ParticlesSystemComponent");
                     return sol::nil;
                 } else if (componentName == "NavigationAgentComponent") {
                     if (auto* component = self->TryGetComponent<NavigationAgentComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a NavigationAgentComponent");
                     return sol::nil;
                 } else if (componentName == "RigidbodyComponent") {
                     if (auto* component = self->TryGetComponent<RigidbodyComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a RigidbodyComponent");
                     return sol::nil;
                 } else if (componentName == "AudioSourceComponent") {
                     if (auto* component = self->TryGetComponent<AudioSourceComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a AudioSourceComponent");
                     return sol::nil;
                 } else if (componentName == "AnimatorComponent") {
                     if (auto* component = self->TryGetComponent<AnimatorComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a AnimatorComponent");
                     return sol::nil;
                 } else if (componentName == "UIImageComponent") {
                     if (auto* component = self->TryGetComponent<UIImageComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a UIImageComponent");
                     return sol::nil;
                 } else if (componentName == "UITextComponent") {
                     if (auto* component = self->TryGetComponent<UITextComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a UITextComponent");
                     return sol::nil;
                 } else if (componentName == "UIToggleComponent") {
                     if (auto* component = self->TryGetComponent<UIToggleComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a UIToggleComponent");
                     return sol::nil;
                 } else if (componentName == "UIButtonComponent") {
                     if (auto* component = self->TryGetComponent<UIButtonComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a UIButtonComponent");
                     return sol::nil;
                 } else if (componentName == "UISliderComponent") {
                     if (auto* component = self->TryGetComponent<UISliderComponent>())
-                        return sol::make_object(luaState, std::ref(*component));
+                        return sol::make_object(luaState, component);
 
                     COFFEE_CORE_ERROR("Lua: Entity does not have a UISliderComponent");
                     return sol::nil;

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaResources.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaResources.cpp
@@ -150,27 +150,39 @@ namespace Coffee
             ),
             "albedo_texture", sol::property(
                 [](PBRMaterial& material) { return material.GetTextures().albedo; },
-                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().albedo = texture; }
+                [](PBRMaterial& material, sol::optional<Ref<Texture2D>> texture) {
+                    material.GetTextures().albedo = texture ? texture.value() : nullptr;
+                }
             ),
             "normal_texture", sol::property(
                 [](PBRMaterial& material) { return material.GetTextures().normal; },
-                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().normal = texture; }
+                [](PBRMaterial& material, sol::optional<Ref<Texture2D>> texture) {
+                    material.GetTextures().normal = texture ? texture.value() : nullptr;
+                }
             ),
             "metallic_texture", sol::property(
                 [](PBRMaterial& material) { return material.GetTextures().metallic; },
-                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().metallic = texture; }
+                [](PBRMaterial& material, sol::optional<Ref<Texture2D>> texture) {
+                    material.GetTextures().metallic = texture ? texture.value() : nullptr;
+                }
             ),
             "roughness_texture", sol::property(
                 [](PBRMaterial& material) { return material.GetTextures().roughness; },
-                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().roughness = texture; }
+                [](PBRMaterial& material, sol::optional<Ref<Texture2D>> texture) {
+                    material.GetTextures().roughness = texture ? texture.value() : nullptr;
+                }
             ),
             "ao_texture", sol::property(
                 [](PBRMaterial& material) { return material.GetTextures().ao; },
-                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().ao = texture; }
+                [](PBRMaterial& material, sol::optional<Ref<Texture2D>> texture) {
+                    material.GetTextures().ao = texture ? texture.value() : nullptr;
+                }
             ),
             "emission_texture", sol::property(
                 [](PBRMaterial& material) { return material.GetTextures().emissive; },
-                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().emissive = texture; }
+                [](PBRMaterial& material, sol::optional<Ref<Texture2D>> texture) {
+                    material.GetTextures().emissive = texture ? texture.value() : nullptr;
+                }
             ),
             "new", sol::factories([](const std::string& name, sol::optional<Coffee::PBRMaterialTextures> textures) {
                 if (textures) {
@@ -220,7 +232,7 @@ namespace Coffee
     {
         luaState.set_function("load", [&](const std::string& path) -> sol::object
         {
-            std::filesystem::path filePath(path);
+            std::filesystem::path filePath = Project::GetActive()->GetProjectDirectory() / path;
             ResourceType type = GetResourceTypeFromExtension(filePath);
     
             switch (type)

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaResources.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaResources.cpp
@@ -1,0 +1,251 @@
+#include "LuaResources.h"
+#include "CoffeeEngine/IO/Resource.h"
+#include "CoffeeEngine/IO/ResourceUtils.h"
+#include "CoffeeEngine/Renderer/Material.h"
+#include "CoffeeEngine/Renderer/Shader.h"
+#include "CoffeeEngine/Renderer/Texture.h"
+#include "CoffeeEngine/Renderer/Mesh.h"
+#include <sol/property.hpp>
+
+namespace Coffee
+{
+    void RegisterResourcesBindings(sol::state& luaState)
+    {
+        // ResourceType enum binding
+        luaState.new_enum("ResourceType",
+            "Unknown", ResourceType::Unknown,
+            "Texture", ResourceType::Texture,
+            "Texture2D", ResourceType::Texture2D,
+            "Cubemap", ResourceType::Cubemap,
+            "Model", ResourceType::Model,
+            "Mesh", ResourceType::Mesh,
+            "Shader", ResourceType::Shader,
+            "Material", ResourceType::Material,
+            "PBRMaterial", ResourceType::PBRMaterial,
+            "ShaderMaterial", ResourceType::ShaderMaterial,
+            "AnimationSystem", ResourceType::AnimationSystem,
+            "Skeleton", ResourceType::Skeleton,
+            "Animation", ResourceType::Animation,
+            "AnimationController", ResourceType::AnimationController,
+            "Prefab", ResourceType::Prefab
+        );
+
+        // Base Resource class binding
+        luaState.new_usertype<Resource>("Resource",
+            "get_name", &Resource::GetName,
+            "get_uuid", &Resource::GetUUID,
+            "get_type", &Resource::GetType,
+            "get_path", [](Resource& resource) { return resource.GetPath().string(); }
+        );
+
+        // Shader class binding (inherits from Resource)
+        luaState.new_usertype<Shader>("Shader",
+            sol::base_classes, sol::bases<Resource>()
+    /*         "setBool", &Shader::setBool,
+            "setInt", &Shader::setInt,
+            "setFloat", &Shader::setFloat,
+            "setVec2", &Shader::setVec2,
+            "setVec3", &Shader::setVec3,
+            "setVec4", &Shader::setVec4,
+            "setMat2", &Shader::setMat2,
+            "setMat3", &Shader::setMat3,
+            "setMat4", &Shader::setMat4 */
+        );
+
+        // Model class binding (inherits from Resource)
+    /*     luaState.new_usertype<Model>("Model",
+            sol::base_classes, sol::bases<Resource>(),
+            "GetMeshes", &Model::GetMeshes,
+            "AddMesh", &Model::AddMesh,
+            "GetNodeName", &Model::GetNodeName,
+            "GetParent", &Model::GetParent,
+            "GetChildren", &Model::GetChildren,
+            "GetTransform", &Model::GetTransform,
+            "HasAnimations", &Model::HasAnimations,
+            "GetSkeleton", &Model::GetSkeleton,
+            "GetAnimationController", &Model::GetAnimationController
+        ); */
+
+        // MaterialRenderSettings struct binding
+
+        // enu, TransparencyMode, CullMode, BlendMode
+/*         luaState.new_usertype<MaterialRenderSettings>("MaterialRenderSettings",
+            "transparencyMode", &MaterialRenderSettings::transparencyMode,
+            "alphaCutoff", &MaterialRenderSettings::alphaCutoff,
+            "blendMode", &MaterialRenderSettings::blendMode,
+            "cullMode", &MaterialRenderSettings::cullMode,
+            "depthTest", &MaterialRenderSettings::depthTest,
+            "wireframe", &MaterialRenderSettings::wireframe
+        ); */
+        luaState.new_enum("TransparencyMode",
+            "Disabled", MaterialRenderSettings::TransparencyMode::Disabled,
+            "Alpha", MaterialRenderSettings::TransparencyMode::Alpha,
+            "AlphaBlend", MaterialRenderSettings::TransparencyMode::AlphaCutoff
+        );
+        luaState.new_enum("CullMode",
+            "Front", MaterialRenderSettings::CullMode::Front,
+            "Back", MaterialRenderSettings::CullMode::Back,
+            "None", MaterialRenderSettings::CullMode::None
+        );
+
+        luaState.new_enum("BlendMode",
+            "Mix", MaterialRenderSettings::BlendMode::Mix,
+            "Add", MaterialRenderSettings::BlendMode::Add,
+            "Subtract", MaterialRenderSettings::BlendMode::Subtract,
+            "Multiply", MaterialRenderSettings::BlendMode::Multiply
+        );
+
+        // Material class binding (inherits from Resource)
+        luaState.new_usertype<Material>("Material",
+            sol::base_classes, sol::bases<Resource>(),
+            "shader", sol::property(&Material::GetShader/* , &Material::SetShader */), // TODO: Move the SetShader to Material class
+            "transparency_mode", sol::property(
+                [](Material& material) { return material.GetRenderSettings().transparencyMode; },
+                [](Material& material, MaterialRenderSettings::TransparencyMode mode) { material.GetRenderSettings().transparencyMode = mode; }
+            ),
+            "alpha_cutoff", sol::property(
+                [](Material& material) { return material.GetRenderSettings().alphaCutoff; },
+                [](Material& material, float cutoff) { material.GetRenderSettings().alphaCutoff = cutoff; }
+            ),
+            "blend_mode", sol::property(
+                [](Material& material) { return material.GetRenderSettings().blendMode; },
+                [](Material& material, MaterialRenderSettings::BlendMode mode) { material.GetRenderSettings().blendMode = mode; }
+            ),
+            "cull_mode", sol::property(
+                [](Material& material) { return material.GetRenderSettings().cullMode; },
+                [](Material& material, MaterialRenderSettings::CullMode mode) { material.GetRenderSettings().cullMode = mode; }
+            ),
+            "depth_test", sol::property(
+                [](Material& material) { return material.GetRenderSettings().depthTest; },
+                [](Material& material, bool depthTest) { material.GetRenderSettings().depthTest = depthTest; }
+            ),
+            "wireframe", sol::property(
+                [](Material& material) { return material.GetRenderSettings().wireframe; },
+                [](Material& material, bool wireframe) { material.GetRenderSettings().wireframe = wireframe; }
+            )
+        );
+
+        // PBRMaterial class binding (inherits from Material)
+        luaState.new_usertype<PBRMaterial>("PBRMaterial",
+            sol::base_classes, sol::bases<Material>(),
+            "color", sol::property(
+                [](PBRMaterial& material) { return material.GetProperties().color; },
+                [](PBRMaterial& material, const glm::vec4& color) { material.GetProperties().color = color; }
+            ),
+            "metalness", sol::property(
+                [](PBRMaterial& material) { return material.GetProperties().metallic; },
+                [](PBRMaterial& material, float metalness) { material.GetProperties().metallic = metalness; }
+            ),
+            "roughness", sol::property(
+                [](PBRMaterial& material) { return material.GetProperties().roughness; },
+                [](PBRMaterial& material, float roughness) { material.GetProperties().roughness = roughness; }
+            ),
+            "ao", sol::property(
+                [](PBRMaterial& material) { return material.GetProperties().ao; },
+                [](PBRMaterial& material, float ao) { material.GetProperties().ao = ao; }
+            ),
+            "emission", sol::property(
+                [](PBRMaterial& material) { return material.GetProperties().emissive; },
+                [](PBRMaterial& material, const glm::vec4& emission) { material.GetProperties().emissive = emission; }
+            ),
+            "albedo_texture", sol::property(
+                [](PBRMaterial& material) { return material.GetTextures().albedo; },
+                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().albedo = texture; }
+            ),
+            "normal_texture", sol::property(
+                [](PBRMaterial& material) { return material.GetTextures().normal; },
+                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().normal = texture; }
+            ),
+            "metallic_texture", sol::property(
+                [](PBRMaterial& material) { return material.GetTextures().metallic; },
+                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().metallic = texture; }
+            ),
+            "roughness_texture", sol::property(
+                [](PBRMaterial& material) { return material.GetTextures().roughness; },
+                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().roughness = texture; }
+            ),
+            "ao_texture", sol::property(
+                [](PBRMaterial& material) { return material.GetTextures().ao; },
+                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().ao = texture; }
+            ),
+            "emission_texture", sol::property(
+                [](PBRMaterial& material) { return material.GetTextures().emissive; },
+                [](PBRMaterial& material, Ref<Texture2D> texture) { material.GetTextures().emissive = texture; }
+            ),
+            "new", sol::factories([](const std::string& name, sol::optional<Coffee::PBRMaterialTextures> textures) {
+                if (textures) {
+                    return Coffee::PBRMaterial::Create(name, &textures.value());
+                } else {
+                    return Coffee::PBRMaterial::Create(name, nullptr);
+                }
+            })
+        );
+
+        // ShaderMaterial class binding (inherits from Material)
+        luaState.new_usertype<ShaderMaterial>("ShaderMaterial",
+            sol::base_classes, sol::bases<Material>(),
+            "new", sol::factories([](const std::string& name) {
+                return Coffee::ShaderMaterial::Create(name, nullptr);
+            })
+        );
+
+        // Mesh class binding (inherits from Resource)
+/*         luaState.new_usertype<Mesh>("Mesh",
+            sol::base_classes, sol::bases<Resource>()
+        ); */
+
+        // Texture class binding (inherits from Resource)
+        luaState.new_usertype<Texture>("Texture",
+            sol::base_classes, sol::bases<Resource>(),
+            "width", &Texture::GetWidth,
+            "height", &Texture::GetHeight,
+            "image_format", &Texture::GetImageFormat
+        );
+
+        // Texture2D class binding (inherits from Texture)
+        luaState.new_usertype<Texture2D>("Texture2D",
+            sol::base_classes, sol::bases<Texture>(),
+            "resize", &Texture2D::Resize,
+            "clear", &Texture2D::Clear,
+            "set_data", &Texture2D::SetData
+        );
+
+        // Cubemap class binding (inherits from Texture)
+        luaState.new_usertype<Cubemap>("Cubemap",
+            sol::base_classes, sol::bases<Texture>()
+        );
+    }
+
+    void RegisterResourceLoadingBindings(sol::state& luaState)
+    {
+        luaState.set_function("load", [&](const std::string& path) -> sol::object
+        {
+            std::filesystem::path filePath(path);
+            ResourceType type = GetResourceTypeFromExtension(filePath);
+    
+            switch (type)
+            {
+                case ResourceType::Texture2D:
+                {
+                    return sol::make_object(luaState, ResourceLoader::Load<Texture2D>(filePath));
+                }
+                case ResourceType::Cubemap:
+                {
+                    return sol::make_object(luaState, ResourceLoader::Load<Cubemap>(filePath));
+                }
+                case ResourceType::Shader:
+                {
+                    return sol::make_object(luaState, ResourceLoader::Load<Shader>(filePath));
+                }
+                case ResourceType::ShaderMaterial:
+                {
+                    return sol::make_object(luaState, ResourceLoader::Load<ShaderMaterial>(filePath));
+                }
+                case ResourceType::PBRMaterial:
+                {
+                    return sol::make_object(luaState, ResourceLoader::Load<PBRMaterial>(filePath));
+                }
+            }
+        });
+    }
+}

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaResources.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaResources.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <sol/sol.hpp>
+
+namespace Coffee {
+    void RegisterResourcesBindings(sol::state& luaState);
+    void RegisterResourceLoadingBindings(sol::state& luaState);
+}

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/LuaBackend.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/LuaBackend.cpp
@@ -12,7 +12,8 @@
 #include "Bindings/LuaScene.h"
 #include "Bindings/LuaTimer.h"
 #include "CoffeeEngine/Core/Log.h"
-#include "CoffeeEngine/Scripting/Lua/LuaScript.h"
+#include "Bindings/LuaResources.h"
+#include "LuaScript.h"
 
 #include <fstream>
 #include <lua.h>
@@ -43,6 +44,8 @@ namespace Coffee {
         RegisterPrefabBindings(luaState);
         RegisterApplicationBindings(luaState);
         RegisterAudioBindings(luaState);
+        RegisterResourcesBindings(luaState);
+        RegisterResourceLoadingBindings(luaState);
     }
 
     Ref<Script> LuaBackend::CreateScript(const std::filesystem::path& path) {


### PR DESCRIPTION
This pull request introduces significant updates to the material and shader systems in the Coffee Engine, improving flexibility, transparency handling, and user interaction in the editor. The most important changes include adding support for transparency modes in materials, enhancing the editor's material and shader selection workflows, and updating embedded shaders to support these new features.

### Material and Transparency Enhancements:
* Added support for transparency modes (`Opaque`, `Alpha`, `AlphaCutoff`) in materials, along with an `alphaCutoff` threshold for `AlphaCutoff` mode. These changes are reflected in the `Material` struct and the embedded `StandardShader`.

### Editor Workflow Improvements:
* Enhanced the material selection workflow in the `SceneTreePanel` to allow users to create or assign materials interactively. This includes support for `PBRMaterial` and `ShaderMaterial`, along with a popup for quick shader loading.
* Updated entity creation to use `PBRMaterial` by default instead of a generic `Material`.

### Shader System Updates:
* Added a new default custom shader file (`DefaultCustomShader.glsl`) to support user-defined shaders with vertex and fragment stages.
* Modified the `SimpleGridShader` to include an `EntityID` output and improved grid rendering logic for better visual fidelity.

### Resource Management:
* Updated the resource import system to distinguish between `PBRMaterial` and other material types, ensuring proper handling during resource creation.

### Miscellaneous:
* Introduced a `ShaderMaterial` for grid rendering in the editor, replacing the previous approach and enabling transparency and culling settings.
* Added new includes for `ResourceRegistry` and file handling in `SceneTreePanel.cpp` to support shader and material workflows.