### PR TITLE
Scene Debug Flags

### DIFF
--- a/CoffeeEditor/Panels/SceneTreePanel.cpp
+++ b/CoffeeEditor/Panels/SceneTreePanel.cpp
@@ -2109,7 +2109,15 @@ namespace Coffee
             bool isCollapsingHeaderOpen = true;
             if (ImGui::CollapsingHeader("NavMesh", &isCollapsingHeaderOpen, ImGuiTreeNodeFlags_DefaultOpen))
             {
-                ImGui::Checkbox("Show NavMesh", &navMeshComponent.ShowDebug);
+                bool showComponent = navMeshComponent.ShowDebug;
+                if (ImGui::Checkbox("Show NavMesh", &showComponent))
+                {
+                    navMeshComponent.ShowDebug = showComponent;
+                    
+                    if (showComponent)
+                        m_Context->m_SceneDebugFlags.ShowNavMesh = true;
+                }
+                
                 ImGui::DragFloat("Walkable Slope Angle", &navMeshComponent.GetNavMesh()->WalkableSlopeAngle, 0.1f, 0.1f, 60.0f);
 
                 if (ImGui::SmallButton("Generate NavMesh"))
@@ -2131,7 +2139,14 @@ namespace Coffee
             {
                 auto view = m_Context->m_Registry.view<NavMeshComponent>();
 
-                ImGui::Checkbox("Show Path", &navigationAgentComponent.ShowDebug);
+                bool showComponent = navigationAgentComponent.ShowDebug;
+                if (ImGui::Checkbox("Show Path", &showComponent))
+                {
+                    navigationAgentComponent.ShowDebug = showComponent;
+                    
+                    if (showComponent)
+                        m_Context->m_SceneDebugFlags.ShowNavMeshPath = true;
+                }
 
                 if (ImGui::BeginCombo("NavMesh", navigationAgentComponent.GetNavMeshComponent() ? std::to_string(navigationAgentComponent.GetNavMeshComponent()->GetNavMeshUUID()).c_str() : "Select NavMesh"))
                 {

--- a/CoffeeEditor/src/EditorLayer.cpp
+++ b/CoffeeEditor/src/EditorLayer.cpp
@@ -252,7 +252,7 @@ namespace Coffee {
                 if (ImGui::MenuItem(ICON_LC_FILE_PLUS_2 " New Project...", "Ctrl+N")) { NewProject(); }
                 if (ImGui::MenuItem(ICON_LC_FOLDER_OPEN " Open Project...", "Ctrl+O")) { OpenProject(); }
                 if (ImGui::MenuItem(ICON_LC_SAVE " Save Project", "Ctrl+S")) { SaveProject(); }
-                if(ImGui::MenuItem(ICON_LC_SETTINGS " Project Settings", nullptr, mainMenuWindows.ProjectSettings))
+                if (ImGui::MenuItem(ICON_LC_SETTINGS " Project Settings", nullptr, mainMenuWindows.ProjectSettings))
                 {
                     mainMenuWindows.ProjectSettings = !mainMenuWindows.ProjectSettings;
                 }
@@ -289,6 +289,52 @@ namespace Coffee {
                 }
                 ImGui::EndMenu();
             }
+            if (ImGui::BeginMenu("Debug"))
+            {
+                Ref<Scene> activeScene = SceneManager::GetActiveScene();
+                bool isSceneActive = activeScene != nullptr;
+
+                if (!isSceneActive)
+                    ImGui::BeginDisabled();
+
+                if (ImGui::MenuItem("Debug Draw", nullptr, isSceneActive ? activeScene->GetDebugFlags().DebugDraw : false))
+                {
+                    if (isSceneActive)
+                    {
+                        // Toggle the debug draw flag
+                        bool newState = !activeScene->GetDebugFlags().DebugDraw;
+                        activeScene->GetDebugFlags().DebugDraw = newState;
+                        
+                        // Set all other debug flags to match the main debug draw flag
+                        activeScene->GetDebugFlags().ShowOctree = newState;
+                        activeScene->GetDebugFlags().ShowColliders = newState;
+                        activeScene->GetDebugFlags().ShowNavMesh = newState;
+                        activeScene->GetDebugFlags().ShowNavMeshPath = newState;
+                    }
+                }
+
+                if (ImGui::MenuItem("Show Octree", nullptr, isSceneActive ? activeScene->GetDebugFlags().ShowOctree : false))
+                    if (isSceneActive)
+                        activeScene->GetDebugFlags().ShowOctree = !activeScene->GetDebugFlags().ShowOctree;
+
+                if (ImGui::MenuItem("Show Colliders", nullptr, isSceneActive ? activeScene->GetDebugFlags().ShowColliders : false))
+                    if (isSceneActive)
+                        activeScene->GetDebugFlags().ShowColliders = !activeScene->GetDebugFlags().ShowColliders;
+
+                if (ImGui::MenuItem("Show NavMesh", nullptr, isSceneActive ? activeScene->GetDebugFlags().ShowNavMesh : false))
+                    if (isSceneActive)
+                        activeScene->GetDebugFlags().ShowNavMesh = !activeScene->GetDebugFlags().ShowNavMesh;
+
+                if (ImGui::MenuItem("Show NavMeshPath", nullptr, isSceneActive ? activeScene->GetDebugFlags().ShowNavMeshPath : false))
+                    if (isSceneActive)
+                        activeScene->GetDebugFlags().ShowNavMeshPath = !activeScene->GetDebugFlags().ShowNavMeshPath;
+
+                if (!isSceneActive)
+                    ImGui::EndDisabled();
+
+                ImGui::EndMenu();
+            }
+
             if (ImGui::BeginMenu("About"))
             {
                 if(ImGui::MenuItem("About Coffee Engine"))

--- a/CoffeeEditor/src/EditorLayer.h
+++ b/CoffeeEditor/src/EditorLayer.h
@@ -59,8 +59,6 @@ namespace Coffee {
         RenderTarget* m_ViewportRenderTarget;
 
         Ref<Scene> m_EditorScene;
-        Ref<Scene> m_ActiveScene;
-
         EditorCamera m_EditorCamera;
 
         bool m_ViewportFocused = false, m_ViewportHovered = false;

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer2D.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer2D.cpp
@@ -57,7 +57,7 @@ namespace Coffee {
 
     struct Batch
     {
-        static const uint32_t MaxQuadCount = 20000; // maybe this can be increased even more
+        static const uint32_t MaxQuadCount = 10000; // Think of increasing this number to 20000
         static const uint32_t MaxVertices = MaxQuadCount * 4;
         static const uint32_t MaxIndices = MaxQuadCount * 6;
         static const uint32_t MaxTextureSlots = 32;

--- a/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer2D.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Renderer/Renderer2D.cpp
@@ -57,7 +57,7 @@ namespace Coffee {
 
     struct Batch
     {
-        static const uint32_t MaxQuadCount = 10000; // Think of increasing this number to 20000
+        static const uint32_t MaxQuadCount = 20000; // maybe this can be increased even more
         static const uint32_t MaxVertices = MaxQuadCount * 4;
         static const uint32_t MaxIndices = MaxQuadCount * 6;
         static const uint32_t MaxTextureSlots = 32;

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -493,9 +493,15 @@ namespace Coffee {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
             for (auto& entity : navMeshViewDebug) {
                 auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
-                if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
-                    navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                if (navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
+                    navMeshComponent.ShowDebug = m_SceneDebugFlags.ShowNavMesh;
                 }
+            }
+        } else {
+            auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            for (auto& entity : navMeshViewDebug) {
+                auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
+                navMeshComponent.ShowDebug = false;
             }
         }
 
@@ -503,8 +509,14 @@ namespace Coffee {
             auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
             for (auto& agent : navigationAgentViewDebug) {
                 auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
-                if (navAgentComponent.ShowDebug && navAgentComponent.GetPathFinder())
-                    navAgentComponent.GetPathFinder()->RenderPath(navAgentComponent.Path);
+                if (navAgentComponent.GetNavMeshComponent())
+                    navAgentComponent.ShowDebug = m_SceneDebugFlags.ShowNavMeshPath;
+            }
+        } else {
+            auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            for (auto& agent : navigationAgentViewDebug) {
+                auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
+                navAgentComponent.ShowDebug = false;
             }
         }
     }

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -680,9 +680,15 @@ namespace Coffee {
             auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
             for (auto& entity : navMeshViewDebug) {
                 auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
-                if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
-                    navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                if (navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
+                    navMeshComponent.ShowDebug = m_SceneDebugFlags.ShowNavMesh;
                 }
+            }
+        } else {
+            auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            for (auto& entity : navMeshViewDebug) {
+                auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
+                navMeshComponent.ShowDebug = false;
             }
         }
 
@@ -690,8 +696,14 @@ namespace Coffee {
             auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
             for (auto& agent : navigationAgentViewDebug) {
                 auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
-                if (navAgentComponent.ShowDebug && navAgentComponent.GetPathFinder())
-                    navAgentComponent.GetPathFinder()->RenderPath(navAgentComponent.Path);
+                if (navAgentComponent.GetNavMeshComponent())
+                    navAgentComponent.ShowDebug = m_SceneDebugFlags.ShowNavMeshPath;
+            }
+        } else {
+            auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            for (auto& agent : navigationAgentViewDebug) {
+                auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
+                navAgentComponent.ShowDebug = false;
             }
         }
 

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -470,10 +470,29 @@ namespace Coffee {
             }
         }
 
-
-        m_PhysicsWorld.drawCollisionShapes();
-
         UIManager::UpdateUI(m_Registry);
+
+        // Debug Draw
+        if (m_SceneDebugFlags.ShowOctree) m_Octree.DebugDraw();
+        if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
+        if (m_SceneDebugFlags.ShowNavMesh) {
+            auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            for (auto& entity : navMeshViewDebug) {
+                auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
+                if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
+                    navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                }
+            }
+        }
+
+        if (m_SceneDebugFlags.ShowNavMeshPath) {
+            auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            for (auto& agent : navigationAgentViewDebug) {
+                auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
+                if (navAgentComponent.ShowDebug && navAgentComponent.GetPathFinder())
+                    navAgentComponent.GetPathFinder()->RenderPath(navAgentComponent.Path);
+            }
+        }
     }
 
 
@@ -638,7 +657,28 @@ namespace Coffee {
                                      Renderer2D::RenderMode::World);
             }
 
-            
+        }
+
+        // Debug Draw
+        if (m_SceneDebugFlags.ShowOctree) m_Octree.DebugDraw();
+        if (m_SceneDebugFlags.ShowColliders) m_PhysicsWorld.drawCollisionShapes();
+        if (m_SceneDebugFlags.ShowNavMesh) {
+            auto navMeshViewDebug = m_Registry.view<ActiveComponent, NavMeshComponent>();
+            for (auto& entity : navMeshViewDebug) {
+                auto& navMeshComponent = navMeshViewDebug.get<NavMeshComponent>(entity);
+                if (navMeshComponent.ShowDebug && navMeshComponent.GetNavMesh() && navMeshComponent.GetNavMesh()->IsCalculated()) {
+                    navMeshComponent.GetNavMesh()->RenderWalkableAreas();
+                }
+            }
+        }
+
+        if (m_SceneDebugFlags.ShowNavMeshPath) {
+            auto navigationAgentViewDebug = m_Registry.view<ActiveComponent, NavigationAgentComponent>();
+            for (auto& agent : navigationAgentViewDebug) {
+                auto& navAgentComponent = navigationAgentViewDebug.get<NavigationAgentComponent>(agent);
+                if (navAgentComponent.ShowDebug && navAgentComponent.GetPathFinder())
+                    navAgentComponent.GetPathFinder()->RenderPath(navAgentComponent.Path);
+            }
         }
 
         UIManager::UpdateUI(m_Registry);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.h
@@ -27,6 +27,15 @@ namespace Coffee {
     class Entity;
     class Model;
 
+    struct SceneDebugFlags
+    {
+        bool DebugDraw = false;
+        bool ShowNavMesh = false;
+        bool ShowNavMeshPath = false;
+        bool ShowColliders = false;
+        bool ShowOctree = false;
+    };
+
     /**
      * @brief Class representing a scene.
      * @ingroup scene
@@ -132,6 +141,9 @@ namespace Coffee {
         void UpdateAudioComponentsPositions();
 
         const std::filesystem::path& GetFilePath() { return m_FilePath; }
+
+        SceneDebugFlags& GetDebugFlags() { return m_SceneDebugFlags; }
+
 
 
         /**
@@ -293,6 +305,7 @@ namespace Coffee {
         Scope<SceneTree> m_SceneTree;
         Octree<Ref<Mesh>> m_Octree;
         PhysicsWorld m_PhysicsWorld;
+        SceneDebugFlags m_SceneDebugFlags;
 
         // Temporal: Scenes should be Resources and the Base Resource class already has a path variable.
         std::filesystem::path m_FilePath;

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaScene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaScene.cpp
@@ -7,12 +7,30 @@
 void Coffee::RegisterSceneBindings(sol::state& luaState)
 {
     luaState.new_usertype<Scene>("Scene",
-            "create_entity", &Scene::CreateEntity,
-            "destroy_entity", &Scene::DestroyEntity,
-            "duplicate_entity", &Scene::Duplicate,
-            "get_entity_by_name", &Scene::GetEntityByName,
-            "get_all_entities", &Scene::GetAllEntities
-        );
+        "create_entity", &Scene::CreateEntity,
+        "destroy_entity", &Scene::DestroyEntity,
+        "duplicate_entity", &Scene::Duplicate,
+        "get_entity_by_name", &Scene::GetEntityByName,
+        "get_all_entities", &Scene::GetAllEntities,
+        "debug_flags", sol::property(&Scene::GetDebugFlags)
+    );
+    
+    luaState.new_usertype<SceneDebugFlags>("SceneDebugFlags",
+        "debug_draw", sol::property(
+            [](const SceneDebugFlags& self) { return self.DebugDraw; },
+            [](SceneDebugFlags& self, const bool value) {
+                self.DebugDraw = value;
+                self.ShowNavMesh = value;
+                self.ShowNavMeshPath = value;
+                self.ShowColliders = value;
+                self.ShowOctree = value;
+            }
+        ),
+        "show_nav_mesh", &SceneDebugFlags::ShowNavMesh,
+        "show_nav_mesh_path", &SceneDebugFlags::ShowNavMeshPath,
+        "show_colliders", &SceneDebugFlags::ShowColliders,
+        "show_octree", &SceneDebugFlags::ShowOctree
+    );
 
     luaState.new_usertype<SceneManager>("SceneManager",
         "preload_scene", [](const std::string& scenePath) {


### PR DESCRIPTION
## Debugging Features
* Introduced a new `SceneDebugFlags` structure in `Scene.h` to manage various debug visualization options, such as `DebugDraw`, `ShowNavMesh`, `ShowNavMeshPath`, `ShowColliders`, and `ShowOctree`.

* Added logic to `Scene.cpp` to conditionally render debug visualizations (e.g., NavMesh, NavMesh paths, colliders, and octree) based on the state of `SceneDebugFlags`.

## Editor UI Enhancements
* Updated `SceneTreePanel.cpp` to synchronize UI checkboxes with the `SceneDebugFlags` state, ensuring that toggling a checkbox updates the corresponding debug flag.
* Added a new "Debug" menu to the editor in `EditorLayer.cpp`, providing options to toggle debug features directly from the UI.

## Lua Scripting Integration
* Extended Lua bindings in `LuaScene.cpp` to expose the `SceneDebugFlags` structure, allowing runtime control of debug visualization options through Lua scripts.

## Code Cleanup
* Removed an unused `m_ActiveScene` member from `EditorLayer.h` to streamline the codebase.