### PR TITLE
Hotfix audio path

### DIFF
--- a/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
@@ -8,7 +8,7 @@
 
 namespace Coffee
 {
-    const std::filesystem::path Audio::DefaultAudioPath = std::filesystem::current_path() / "assets/audio/Wwise Project/GeneratedSoundBanks/Windows";
+    const std::filesystem::path Audio::DefaultAudioPath = std::filesystem::absolute(std::filesystem::current_path() / "assets/audio/Wwise Project/GeneratedSoundBanks/Windows");
     std::filesystem::path Audio::m_ActiveAudioPath = Audio::DefaultAudioPath;
 
     // Global pointer for the low-level IO
@@ -217,7 +217,7 @@ namespace Coffee
             COFFEE_CORE_WARN("Audio folder path not defined in project");
             return;
         }
-        COFFEE_CORE_INFO("Project audio directory found, loading audio banks...");
+        COFFEE_CORE_INFO("Project audio directory found, loading audio banks from " + std::filesystem::absolute(audioPath).string());
 
 
         m_ActiveAudioPath = audioPath;
@@ -336,7 +336,7 @@ namespace Coffee
 
     bool Audio::LoadAudioBanks()
     {
-        std::string audioPath = (m_ActiveAudioPath / "SoundbanksInfo.json").string();
+        std::string audioPath = std::filesystem::absolute(m_ActiveAudioPath / "SoundbanksInfo.json").string();
         std::ifstream file(audioPath);
         if (!file.is_open())
             return false;

--- a/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
@@ -8,7 +8,7 @@
 
 namespace Coffee
 {
-    const std::filesystem::path Audio::DefaultAudioPath = "assets/audio/Wwise Project/GeneratedSoundBanks/Windows";
+    const std::filesystem::path Audio::DefaultAudioPath = std::filesystem::current_path() / "assets/audio/Wwise Project/GeneratedSoundBanks/Windows";
     std::filesystem::path Audio::m_ActiveAudioPath = Audio::DefaultAudioPath;
 
     // Global pointer for the low-level IO
@@ -43,7 +43,10 @@ namespace Coffee
 
         g_lowLevelIO->SetBasePath(m_ActiveAudioPath.c_str());
 
-        LoadAudioBanks();
+        if (LoadAudioBanks())
+            COFFEE_CORE_INFO("Loaded audio banks");
+        else
+            COFFEE_CORE_ERROR("Failed to load audio banks");
 
         AudioZone::SearchAvailableBusChannels();
     }
@@ -223,7 +226,7 @@ namespace Coffee
     }
     void Audio::OnProjectUnload()
     {
-        COFFEE_CORE_INFO("Loading default audio banks");
+        COFFEE_CORE_INFO("Loading default audio banks...");
 
         Shutdown();
         Init();
@@ -334,7 +337,8 @@ namespace Coffee
 
     bool Audio::LoadAudioBanks()
     {
-        std::ifstream file("assets/audio/Wwise Project/GeneratedSoundBanks/Windows/SoundbanksInfo.json");
+        std::string audioPath = (m_ActiveAudioPath / "SoundbanksInfo.json").string();
+        std::ifstream file(audioPath);
         if (!file.is_open())
             return false;
 

--- a/CoffeeEngine/src/CoffeeEngine/Audio/Audio.h
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/Audio.h
@@ -259,6 +259,8 @@ namespace Coffee {
          * @return True if successful, false otherwise.
          */
         static bool LoadAudioBanks();
+
+        static bool ReloadAudioBanks();
     };
 } // namespace Coffee
 CEREAL_CLASS_VERSION(Coffee::Audio::AudioBank, 0);

--- a/CoffeeEngine/src/CoffeeEngine/Audio/Audio.h
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/Audio.h
@@ -202,6 +202,8 @@ namespace Coffee {
          */
         static void SetBusVolume(const char* busName, float volume);
 
+        static const std::filesystem::path& GetAudioPath() { return m_ActiveAudioPath; }
+
         static void OnProjectLoad();
 
         static void OnProjectUnload();

--- a/CoffeeEngine/src/CoffeeEngine/Audio/AudioZone.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/AudioZone.cpp
@@ -139,7 +139,7 @@ namespace Coffee
 
     bool AudioZone::SearchAvailableBusChannels()
     {
-        std::ifstream file(Audio::GetAudioPath() / "SoundbanksInfo.json");
+        std::ifstream file(std::filesystem::absolute(Audio::GetAudioPath() / "SoundbanksInfo.json"));
         if (!file.is_open())
             return false;
 

--- a/CoffeeEngine/src/CoffeeEngine/Audio/AudioZone.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/AudioZone.cpp
@@ -139,7 +139,7 @@ namespace Coffee
 
     bool AudioZone::SearchAvailableBusChannels()
     {
-        std::ifstream file("Assets/Audio/Wwise Project/GeneratedSoundBanks/Windows/SoundbanksInfo.json");
+        std::ifstream file(Audio::GetAudioPath() / "SoundbanksInfo.json");
         if (!file.is_open())
             return false;
 


### PR DESCRIPTION
- Fixed not actually loading the custom path set in project settings
- Changed audio reload logic to not completely shutdown the engine and instead just reload audiobanks
  - Includes a change to not unregister all gameobjects when changing to another audio folder