### PR TITLE
Save UI transform relative to anchors and round values

### DIFF
--- a/CoffeeEngine/src/CoffeeEngine/UI/UIManager.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/UI/UIManager.cpp
@@ -574,8 +574,17 @@ namespace Coffee {
             if (anchor)
             {
                 glm::vec2 anchoredPos = anchor->GetAnchoredPosition(item.ParentSize);
+
+                anchoredPos.x = std::round(anchoredPos.x * 1000.0f) / 1000.0f;
+                anchoredPos.y = std::round(anchoredPos.y * 1000.0f) / 1000.0f;
+
                 transformComponent.SetLocalPosition(glm::vec3(anchoredPos, 0.0f));
-                transformComponent.SetLocalScale(glm::vec3(anchor->GetSize().x, anchor->GetSize().y, 1.0f));
+
+                glm::vec2 anchoredSize = anchor->GetSize();
+                anchoredSize.x = std::round(anchoredSize.x * 1000.0f) / 1000.0f;
+                anchoredSize.y = std::round(anchoredSize.y * 1000.0f) / 1000.0f;
+
+                transformComponent.SetLocalScale(glm::vec3(anchoredSize, 1.0f));
             }
 
             float rotation = transformComponent.GetLocalRotation().z;


### PR DESCRIPTION
Improves consistency when saving UI transforms across different screen resolutions.

- Save the UI transform position based on anchor-relative coordinates instead of absolute screen position to prevent unnecessary changes when users have different viewport sizes.

- Round position and scale values to eliminate insignificant decimal differences and avoid redundant data being saved.