### PR TITLE
Window modes

### DIFF
--- a/CoffeeEngine/src/CoffeeEngine/Core/Window.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Core/Window.cpp
@@ -22,6 +22,7 @@ namespace Coffee {
         ZoneScoped;
 
 		Init(props);
+        m_Mode = WindowMode::Windowed;
 	}
 
 	Window::~Window()
@@ -148,6 +149,29 @@ namespace Coffee {
         SDL_SetWindowIcon(m_Window, icon);
 
         stbi_image_free(pixels);
+    }
+
+    void Window::SetWindowMode(WindowMode mode)
+    {
+        if (m_Mode == mode)
+            return;
+
+        switch (mode)
+        {
+        case WindowMode::Fullscreen:
+            SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN);
+            break;
+        case WindowMode::Windowed:
+        default:
+            SDL_SetWindowFullscreen(m_Window, false);
+            break;
+        }
+        m_Mode = mode;
+    }
+
+    WindowMode Window::GetWindowMode() const
+    {
+        return m_Mode;
     }
 
 }

--- a/CoffeeEngine/src/CoffeeEngine/Core/Window.h
+++ b/CoffeeEngine/src/CoffeeEngine/Core/Window.h
@@ -15,6 +15,15 @@ namespace Coffee {
      */
 
     /**
+     * @brief Enum to represent the window display mode.
+     */
+    enum class WindowMode
+    {
+        Windowed,
+        Fullscreen
+    };
+
+    /**
      * @brief Structure to hold window properties such as title, width, and height.
      */
     struct WindowProps
@@ -102,6 +111,18 @@ namespace Coffee {
         void SetIcon(const std::string& path);
 
         /**
+         * @brief Sets the window mode (windowed, fullscreen).
+         * @param mode The desired window mode.
+         */
+        void SetWindowMode(WindowMode mode);
+
+        /**
+         * @brief Gets the current window mode.
+         * @return The current window mode.
+         */
+        WindowMode GetWindowMode() const;
+
+        /**
          * @brief Gets the native window handle.
          * @return A pointer to the native window.
          */
@@ -141,6 +162,7 @@ namespace Coffee {
         };
 
         WindowData m_Data; ///< The window data.
+        WindowMode m_Mode = WindowMode::Windowed; ///< The current window mode.
     };
 
     /** @} */

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaApplication.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaApplication.cpp
@@ -34,5 +34,20 @@ void Coffee::RegisterApplicationBindings(sol::state& luaState)
         return Application::Get().GetWindow().GetTitle();
     });
 
+    appTable.set_function("set_window_mode", [](WindowMode mode) {
+        Application::Get().GetWindow().SetWindowMode(mode);
+    });
+
+    appTable.set_function("get_window_mode", []() {
+        return Application::Get().GetWindow().GetWindowMode();
+    });
+
+    luaState.new_enum<WindowMode>("WindowMode",
+        {
+            {"Windowed", WindowMode::Windowed},
+            {"Fullscreen", WindowMode::Fullscreen}
+        }
+    );
+
     luaState["App"] = appTable;
 }


### PR DESCRIPTION
### Window Mode Feature Implementation:

* Added a `WindowMode` enum to represent the window display modes (`Windowed` and `Fullscreen`) in `Window.h`.
* Introduced `SetWindowMode` and `GetWindowMode` methods in the `Window` class to allow setting and retrieving the current window mode. These methods include logic to toggle between modes using SDL functions.
* Added a member variable `m_Mode` to the `Window` class to store the current window mode, initialized to `WindowMode::Windowed`.

### Lua Scripting Integration:

* Extended Lua bindings to expose `set_window_mode` and `get_window_mode` functions, enabling window mode management through Lua scripts.
* Registered the `WindowMode` enum in Lua, allowing scripts to reference modes as `WindowMode.Windowed` and `WindowMode.Fullscreen`.