### PR TITLE
Audio improvements with prefabs

### DIFF
--- a/CoffeeEditor/src/EditorLayer.cpp
+++ b/CoffeeEditor/src/EditorLayer.cpp
@@ -864,9 +864,6 @@ namespace Coffee {
 
         if (!path.empty() and path.extension() == ".TeaScene")
         {
-            AudioZone::RemoveAllReverbZones();
-            Audio::UnregisterAllGameObjects();
-
             m_EditorScene = Scene::Load(path);
             SceneManager::ChangeScene(m_EditorScene);
 

--- a/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
@@ -126,13 +126,16 @@ namespace Coffee
 
     void Audio::RegisterAudioSourceComponent(AudioSourceComponent& audioSourceComponent)
     {
+        if (!audioSourceComponent.toRegister)
+            return;
+
         for (const auto& source : audioSources)
         {
             if (source->gameObjectID == audioSourceComponent.gameObjectID)
                 return;
         }
 
-        if (audioSourceComponent.gameObjectID == -1)
+        if (audioSourceComponent.gameObjectID == 0)
             audioSourceComponent.gameObjectID = UUID();
 
         audioSources.push_back(&audioSourceComponent);
@@ -151,19 +154,27 @@ namespace Coffee
 
         UnregisterGameObject(audioSourceComponent.gameObjectID);
 
-        auto it = std::ranges::find(audioSources, &audioSourceComponent);
-        audioSources.erase(it);
+        auto it = std::ranges::find_if(audioSources,
+           [&](const AudioSourceComponent* source) {
+               return source->gameObjectID == audioSourceComponent.gameObjectID;
+           });
+
+        if (it != audioSources.end())
+            audioSources.erase(it);
     }
 
     void Audio::RegisterAudioListenerComponent(AudioListenerComponent& audioListenerComponent)
     {
+        if (!audioListenerComponent.toRegister)
+            return;
+
         for (const auto* listener : audioListeners)
         {
             if (listener->gameObjectID == audioListenerComponent.gameObjectID)
                 return;
         }
 
-        if (audioListenerComponent.gameObjectID == -1)
+        if (audioListenerComponent.gameObjectID == 0)
             audioListenerComponent.gameObjectID = UUID();
 
         audioListeners.push_back(&audioListenerComponent);
@@ -178,8 +189,13 @@ namespace Coffee
 
         audioListenerComponent.toDelete = true;
 
-        auto it = std::ranges::find(audioListeners, &audioListenerComponent);
-        audioListeners.erase(it);
+        auto it = std::ranges::find_if(audioListeners,
+           [&](const AudioListenerComponent* source) {
+               return source->gameObjectID == audioListenerComponent.gameObjectID;
+           });
+
+        if (it != audioListeners.end())
+            audioListeners.erase(it);
     }
 
     void Audio::PlayInitialAudios()

--- a/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Audio/Audio.cpp
@@ -74,6 +74,9 @@ namespace Coffee
         {
             UnregisterAudioListenerComponent(*audioListener);
         }
+
+        audioSources.clear();
+        audioListeners.clear();
     }
 
     void Audio::Set3DPosition(uint64_t gameObjectID, glm::vec3 pos, glm::vec3 forward, glm::vec3 up)
@@ -126,9 +129,6 @@ namespace Coffee
 
     void Audio::RegisterAudioSourceComponent(AudioSourceComponent& audioSourceComponent)
     {
-        if (!audioSourceComponent.toRegister)
-            return;
-
         for (const auto& source : audioSources)
         {
             if (source->gameObjectID == audioSourceComponent.gameObjectID)
@@ -148,8 +148,6 @@ namespace Coffee
         if (!audioSourceComponent.eventName.empty() && audioSourceComponent.isPlaying)
             StopEvent(audioSourceComponent);
 
-        audioSourceComponent.toDelete = true;
-
         AudioZone::UnregisterObject(audioSourceComponent.gameObjectID);
 
         UnregisterGameObject(audioSourceComponent.gameObjectID);
@@ -165,9 +163,6 @@ namespace Coffee
 
     void Audio::RegisterAudioListenerComponent(AudioListenerComponent& audioListenerComponent)
     {
-        if (!audioListenerComponent.toRegister)
-            return;
-
         for (const auto* listener : audioListeners)
         {
             if (listener->gameObjectID == audioListenerComponent.gameObjectID)
@@ -186,8 +181,6 @@ namespace Coffee
     void Audio::UnregisterAudioListenerComponent(AudioListenerComponent& audioListenerComponent)
     {
         UnregisterGameObject(audioListenerComponent.gameObjectID);
-
-        audioListenerComponent.toDelete = true;
 
         auto it = std::ranges::find_if(audioListeners,
            [&](const AudioListenerComponent* source) {
@@ -214,6 +207,8 @@ namespace Coffee
             if (audioSource->isPlaying)
                 StopEvent(*audioSource);
         }
+
+        AK::SoundEngine::StopAll();
     }
 
     void Audio::SetBusVolume(const char* busName, float volume)
@@ -249,7 +244,7 @@ namespace Coffee
 
     void Audio::ProcessAudio()
     {
-        AudioZone::Update();
+        //AudioZone::Update();
 
         AK::SoundEngine::RenderAudio();
     }

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Components.h
@@ -689,49 +689,10 @@ namespace Coffee
         glm::mat4 transform;             ///< The transform of the audio source.
         bool isPlaying = false;          ///< True if the audio source is playing.
         bool isPaused = false;           ///< True if the audio source is paused.
-        bool toDelete = false;           ///< True if the audio source should be deleted.
-        bool toUnregister = false;       ///< True if the audio source should be unregistered.
-        bool toRegister = true;          ///< True if the audio source should be registered.
 
         AudioSourceComponent() = default;
 
         AudioSourceComponent(const AudioSourceComponent& other) { *this = other; }
-
-        ~AudioSourceComponent()
-        {
-            if (isPlaying || playOnAwake)
-                Stop();
-
-            if (toUnregister && !toDelete)
-                Audio::UnregisterAudioSourceComponent(*this);
-        }
-
-        AudioSourceComponent& operator=(const AudioSourceComponent& other)
-        {
-            if (this != &other)
-            {
-                gameObjectID = other.gameObjectID;
-                audioBank = other.audioBank;
-                audioBankName = other.audioBankName;
-                eventName = other.eventName;
-                volume = other.volume;
-                mute = other.mute;
-                playOnAwake = other.playOnAwake;
-                transform = other.transform;
-                isPlaying = other.isPlaying;
-                isPaused = other.isPaused;
-                toDelete = other.toDelete;
-                toUnregister = other.toUnregister;
-                toRegister = other.toRegister;
-
-                if (!toDelete)
-                {
-                    Audio::RegisterAudioSourceComponent(*this);
-                    AudioZone::RegisterObject(gameObjectID, transform[3]);
-                }
-            }
-            return *this;
-        }
 
         static AudioSourceComponent CreateCopy(const AudioSourceComponent& other)
         {
@@ -769,8 +730,7 @@ namespace Coffee
             archive(cereal::make_nvp("GameObjectID", gameObjectID), cereal::make_nvp("AudioBank", audioBank),
                     cereal::make_nvp("AudioBankName", audioBankName), cereal::make_nvp("EventName", eventName),
                     cereal::make_nvp("Volume", volume), cereal::make_nvp("Mute", mute),
-                    cereal::make_nvp("PlayOnAwake", playOnAwake), cereal::make_nvp("Transform", transform),
-                    cereal::make_nvp("ToRegister", toRegister));
+                    cereal::make_nvp("PlayOnAwake", playOnAwake), cereal::make_nvp("Transform", transform));
         }
 
         template <class Archive> void load(Archive& archive, std::uint32_t const version)
@@ -779,11 +739,6 @@ namespace Coffee
                     cereal::make_nvp("AudioBankName", audioBankName), cereal::make_nvp("EventName", eventName),
                     cereal::make_nvp("Volume", volume), cereal::make_nvp("Mute", mute),
                     cereal::make_nvp("PlayOnAwake", playOnAwake), cereal::make_nvp("Transform", transform));
-
-            if (version >= 1)
-            {
-                archive(cereal::make_nvp("ToRegister", toRegister));
-            }
         }
     };
 
@@ -791,29 +746,10 @@ namespace Coffee
     {
         uint64_t gameObjectID = 0; ///< The object ID.
         glm::mat4 transform;        ///< The transform of the audio listener.
-        bool toDelete = false;      ///< True if the audio listener should be deleted.
-        bool toUnregister = false;  ///< True if the audio listener should be unregistered.
-        bool toRegister = true;     ///< True if the audio listener should be registered.
 
         AudioListenerComponent() = default;
 
         AudioListenerComponent(const AudioListenerComponent& other) { *this = other; }
-
-        AudioListenerComponent& operator=(const AudioListenerComponent& other)
-        {
-            if (this != &other)
-            {
-                gameObjectID = other.gameObjectID;
-                transform = other.transform;
-                toDelete = other.toDelete;
-                toUnregister = other.toUnregister;
-                toRegister = other.toRegister;
-
-                if (!toDelete)
-                    Audio::RegisterAudioListenerComponent(*this);
-            }
-            return *this;
-        }
 
         static AudioListenerComponent CreateCopy(const AudioListenerComponent& other)
         {
@@ -825,18 +761,12 @@ namespace Coffee
 
         template <class Archive> void save(Archive& archive, std::uint32_t const version) const
         {
-            archive(cereal::make_nvp("GameObjectID", gameObjectID), cereal::make_nvp("Transform", transform),
-                    cereal::make_nvp("ToRegister", toRegister));
+            archive(cereal::make_nvp("GameObjectID", gameObjectID), cereal::make_nvp("Transform", transform));
         }
 
         template <class Archive> void load(Archive& archive, std::uint32_t const version)
         {
             archive(cereal::make_nvp("GameObjectID", gameObjectID), cereal::make_nvp("Transform", transform));
-
-            if (version >= 1)
-            {
-                archive(cereal::make_nvp("ToRegister", toRegister));
-            }
         }
     };
 
@@ -1487,8 +1417,8 @@ CEREAL_CLASS_VERSION(Coffee::MeshComponent, 0);
 CEREAL_CLASS_VERSION(Coffee::MaterialComponent, 1);
 CEREAL_CLASS_VERSION(Coffee::LightComponent, 1);
 CEREAL_CLASS_VERSION(Coffee::WorldEnvironmentComponent, 1);
-CEREAL_CLASS_VERSION(Coffee::AudioSourceComponent, 1);
-CEREAL_CLASS_VERSION(Coffee::AudioListenerComponent, 1);
+CEREAL_CLASS_VERSION(Coffee::AudioSourceComponent, 0);
+CEREAL_CLASS_VERSION(Coffee::AudioListenerComponent, 0);
 CEREAL_CLASS_VERSION(Coffee::AudioZoneComponent, 0);
 CEREAL_CLASS_VERSION(Coffee::ScriptComponent, 0);
 CEREAL_CLASS_VERSION(Coffee::RigidbodyComponent, 0);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -56,6 +56,17 @@ namespace Coffee {
         CopyComponentToPrefab<UISliderComponent>(sourceEntity, destEntity);
         CopyComponentToPrefab<UIComponent>(sourceEntity, destEntity);
 
+        if (m_Registry.all_of<AudioSourceComponent>(destEntity))
+        {
+            auto& audioSourceComp = m_Registry.get<AudioSourceComponent>(destEntity);
+            audioSourceComp.toRegister = false;
+        }
+
+        if (m_Registry.all_of<AudioListenerComponent>(destEntity))
+        {
+            auto& audioListenerComp = m_Registry.get<AudioListenerComponent>(destEntity);
+            audioListenerComp.toRegister = false;
+        }
         
         // Copy empty components (which don't need values)
         CopyEmptyComponentToPrefab<StaticComponent>(sourceEntity, destEntity);
@@ -252,13 +263,32 @@ namespace Coffee {
                 }
             }
         }
+
+        if (m_Registry.all_of<AudioSourceComponent>(prefabEntity))
+        {
+            const auto& audioSourceComp = m_Registry.get<AudioSourceComponent>(prefabEntity);
+            AudioSourceComponent newAudioSourceComp = AudioSourceComponent::CreateCopy(audioSourceComp);
+            entity.AddComponent<AudioSourceComponent>(newAudioSourceComp);
+
+            auto& audioSourceComponent = entity.GetComponent<AudioSourceComponent>();
+            Audio::RegisterAudioSourceComponent(audioSourceComponent);
+            AudioZone::RegisterObject(audioSourceComponent.gameObjectID, audioSourceComponent.transform[3]);
+        }
+
+        if (m_Registry.all_of<AudioListenerComponent>(prefabEntity))
+        {
+            const auto& audioListenerComp = m_Registry.get<AudioListenerComponent>(prefabEntity);
+            AudioListenerComponent newAudioListenerComp = AudioListenerComponent::CreateCopy(audioListenerComp);
+            entity.AddComponent<AudioListenerComponent>(newAudioListenerComp);
+
+            auto& audioListenerComponent = entity.GetComponent<AudioListenerComponent>();
+            Audio::RegisterAudioListenerComponent(audioListenerComponent);
+        }
         
         // Copy standard components
         CopyComponentToScene<MaterialComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<LightComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<ParticlesSystemComponent>(scene, prefabEntity, entity);
-        CopyComponentToScene<AudioSourceComponent>(scene, prefabEntity, entity);
-        CopyComponentToScene<AudioListenerComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<AudioZoneComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<NavigationAgentComponent>(scene, prefabEntity, entity);
         CopyComponentToScene<NavMeshComponent>(scene, prefabEntity, entity);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Prefab.cpp
@@ -55,18 +55,6 @@ namespace Coffee {
         CopyComponentToPrefab<UIButtonComponent>(sourceEntity, destEntity);
         CopyComponentToPrefab<UISliderComponent>(sourceEntity, destEntity);
         CopyComponentToPrefab<UIComponent>(sourceEntity, destEntity);
-
-        if (m_Registry.all_of<AudioSourceComponent>(destEntity))
-        {
-            auto& audioSourceComp = m_Registry.get<AudioSourceComponent>(destEntity);
-            audioSourceComp.toRegister = false;
-        }
-
-        if (m_Registry.all_of<AudioListenerComponent>(destEntity))
-        {
-            auto& audioListenerComp = m_Registry.get<AudioListenerComponent>(destEntity);
-            audioListenerComp.toRegister = false;
-        }
         
         // Copy empty components (which don't need values)
         CopyEmptyComponentToPrefab<StaticComponent>(sourceEntity, destEntity);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -142,6 +142,39 @@ namespace Coffee {
     }
 
     template <>
+    void CopyComponentIfExists<AudioSourceComponent>(entt::entity destinyEntity, entt::entity sourceEntity, entt::registry& registry)
+    {
+        if(registry.all_of<AudioSourceComponent>(sourceEntity))
+        {
+            const auto& srcComponent = registry.get<AudioSourceComponent>(sourceEntity);
+
+            AudioSourceComponent newComponent = AudioSourceComponent::CreateCopy(srcComponent);
+
+            registry.emplace<AudioSourceComponent>(destinyEntity, std::move(newComponent));
+
+            auto& audioSourceComponent = registry.get<AudioSourceComponent>(destinyEntity);
+            Audio::RegisterAudioSourceComponent(audioSourceComponent);
+            AudioZone::RegisterObject(audioSourceComponent.gameObjectID, audioSourceComponent.transform[3]);
+        }
+    }
+
+    template <>
+    void CopyComponentIfExists<AudioListenerComponent>(entt::entity destinyEntity, entt::entity sourceEntity, entt::registry& registry)
+    {
+        if(registry.all_of<AudioListenerComponent>(sourceEntity))
+        {
+            const auto& srcComponent = registry.get<AudioListenerComponent>(sourceEntity);
+
+            AudioListenerComponent newComponent = AudioListenerComponent::CreateCopy(srcComponent);
+
+            registry.emplace<AudioListenerComponent>(destinyEntity, std::move(newComponent));
+
+            auto& audioListenerComponent = registry.get<AudioListenerComponent>(destinyEntity);
+            Audio::RegisterAudioListenerComponent(audioListenerComponent);
+        }
+    }
+
+    template <>
     void CopyComponentIfExists<RigidbodyComponent>(entt::entity destinyEntity, entt::entity sourceEntity, entt::registry& registry)
     {
         if(registry.all_of<RigidbodyComponent>(sourceEntity))
@@ -283,6 +316,20 @@ namespace Coffee {
                 rbComponent.rb->GetNativeBody()->setUserPointer(nullptr);
                 rbComponent.rb.reset();
             }
+        }
+
+        if (entity.HasComponent<AudioSourceComponent>())
+        {
+            auto& audioSourceComponent = entity.GetComponent<AudioSourceComponent>();
+            if (audioSourceComponent.toUnregister)
+                Audio::UnregisterAudioSourceComponent(audioSourceComponent);
+        }
+
+        if (entity.HasComponent<AudioListenerComponent>())
+        {
+            auto& audioListenerComponent = entity.GetComponent<AudioListenerComponent>();
+            if (audioListenerComponent.toUnregister)
+                Audio::UnregisterAudioListenerComponent(audioListenerComponent);
         }
 
         auto& hierarchyComponent = m_Registry.get<HierarchyComponent>(entity);

--- a/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/Scene.cpp
@@ -321,15 +321,13 @@ namespace Coffee {
         if (entity.HasComponent<AudioSourceComponent>())
         {
             auto& audioSourceComponent = entity.GetComponent<AudioSourceComponent>();
-            if (audioSourceComponent.toUnregister)
-                Audio::UnregisterAudioSourceComponent(audioSourceComponent);
+            Audio::UnregisterAudioSourceComponent(audioSourceComponent);
         }
 
         if (entity.HasComponent<AudioListenerComponent>())
         {
             auto& audioListenerComponent = entity.GetComponent<AudioListenerComponent>();
-            if (audioListenerComponent.toUnregister)
-                Audio::UnregisterAudioListenerComponent(audioListenerComponent);
+            Audio::UnregisterAudioListenerComponent(audioListenerComponent);
         }
 
         auto& hierarchyComponent = m_Registry.get<HierarchyComponent>(entity);
@@ -380,6 +378,19 @@ namespace Coffee {
 
         CollisionSystem::Initialize(this);
 
+        auto audioListenerView = m_Registry.view<AudioListenerComponent>();
+        for (auto& entity : audioListenerView)
+        {
+            auto& audioListenerComponent = audioListenerView.get<AudioListenerComponent>(entity);
+            Audio::RegisterAudioListenerComponent(audioListenerComponent);
+        }
+        auto audioSourceView = m_Registry.view<AudioSourceComponent>();
+        for (auto& entity : audioSourceView)
+        {
+            auto& audioSourceComponent = audioSourceView.get<AudioSourceComponent>(entity);
+            Audio::RegisterAudioSourceComponent(audioSourceComponent);
+            AudioZone::RegisterObject(audioSourceComponent.gameObjectID, audioSourceComponent.transform[3]);
+        }
     }
 
     void Scene::OnInitRuntime()
@@ -445,7 +456,19 @@ namespace Coffee {
             m_Octree->Insert(object);
         }
 
-        Audio::StopAllEvents();
+        auto audioListenerView = m_Registry.view<AudioListenerComponent>();
+        for (auto& entity : audioListenerView)
+        {
+            auto& audioListenerComponent = audioListenerView.get<AudioListenerComponent>(entity);
+            Audio::RegisterAudioListenerComponent(audioListenerComponent);
+        }
+        auto audioSourceView = m_Registry.view<AudioSourceComponent>();
+        for (auto& entity : audioSourceView)
+        {
+            auto& audioSourceComponent = audioSourceView.get<AudioSourceComponent>(entity);
+            Audio::RegisterAudioSourceComponent(audioSourceComponent);
+            AudioZone::RegisterObject(audioSourceComponent.gameObjectID, audioSourceComponent.transform[3]);
+        }
         Audio::PlayInitialAudios();
 
         // Get all entities with ScriptComponent

--- a/CoffeeEngine/src/CoffeeEngine/Scene/SceneManager.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scene/SceneManager.cpp
@@ -93,6 +93,10 @@ namespace Coffee {
             {
                 s_ActiveScene->OnExitEditor();
             }
+
+            Audio::StopAllEvents();
+            AudioZone::RemoveAllReverbZones();
+            Audio::UnregisterAllGameObjects();
         }
     }
 

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaPrefab.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaPrefab.cpp
@@ -30,33 +30,7 @@ namespace Coffee {
                 return Entity();
             }
 
-            Entity prefabEntity = prefab->Instantiate(scene, transform.value_or(glm::mat4(1.0f)));
-
-            std::function<void(Entity&)> markAudioComponentsToDelete = [&](Entity& entity) {
-                if (entity.HasComponent<AudioSourceComponent>())
-                {
-                    auto& audioSource = entity.GetComponent<AudioSourceComponent>();
-                    audioSource.toUnregister = true;
-                }
-
-                if (entity.HasComponent<AudioListenerComponent>())
-                {
-                    auto& audioListener = entity.GetComponent<AudioSourceComponent>();
-                    audioListener.toUnregister = true;
-                }
-
-                if constexpr (requires(Entity e) { e.GetChildren(); })
-                {
-                    for (auto& child : entity.GetChildren())
-                    {
-                        markAudioComponentsToDelete(child);
-                    }
-                }
-            };
-
-            markAudioComponentsToDelete(prefabEntity);
-
-            return prefabEntity;
+            return prefab->Instantiate(scene, transform.value_or(glm::mat4(1.0f)));
         });
     }
 }

--- a/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaScene.cpp
+++ b/CoffeeEngine/src/CoffeeEngine/Scripting/Lua/Bindings/LuaScene.cpp
@@ -41,13 +41,9 @@ void Coffee::RegisterSceneBindings(sol::state& luaState)
         },
         "change_scene", sol::overload(
             [](const std::string& scenePath) {
-                AudioZone::RemoveAllReverbZones();
-                Audio::UnregisterAllGameObjects();
                 SceneManager::ChangeScene(scenePath);
             },
             [](const Ref<Scene>& scene) {
-                AudioZone::RemoveAllReverbZones();
-                Audio::UnregisterAllGameObjects();
                 SceneManager::ChangeScene(scene);
             }
         ),


### PR DESCRIPTION
This pull request introduces several updates to the audio component system in the Coffee Engine, focusing on improving the registration and management of `AudioSourceComponent` and `AudioListenerComponent`. It adds new flags for better control over registration and enhances prefab and scene handling for these components.

### Enhancements to Audio Component Management:

* Introduced `toRegister` and `toUnregister` flags in `AudioSourceComponent` and `AudioListenerComponent` to control component registration and unregistration. These flags are now checked during registration and unregistration processes to prevent redundant operations.

### Prefab and Scene Handling:

* Enhanced prefab instantiation to handle audio components by marking them with `toRegister = false` to avoid unnecessary re-registration. Added logic to copy and register audio components when duplicating entities or instantiating prefabs.

### Unregistration Logic:

* Added logic to unregister audio components when entities are removed or marked with `toUnregister`. This ensures proper cleanup of resources.

These changes collectively ensure that Wwise IDs are correctly registered, improving integration with the audio middleware.